### PR TITLE
[core] Add/improve ignore_unused() function specifiers.

### DIFF
--- a/include/boost/core/ignore_unused.hpp
+++ b/include/boost/core/ignore_unused.hpp
@@ -14,53 +14,53 @@ namespace boost {
 #ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
 
 template <typename... Ts>
-inline void ignore_unused(Ts const& ...)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(Ts const& ...)
 {}
 
 template <typename... Ts>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 #else
 
 template <typename T1>
-inline void ignore_unused(T1 const&)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(T1 const&)
 {}
 
 template <typename T1, typename T2>
-inline void ignore_unused(T1 const&, T2 const&)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(T1 const&, T2 const&)
 {}
 
 template <typename T1, typename T2, typename T3>
-inline void ignore_unused(T1 const&, T2 const&, T3 const&)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(T1 const&, T2 const&, T3 const&)
 {}
 
 template <typename T1, typename T2, typename T3, typename T4>
-inline void ignore_unused(T1 const&, T2 const&, T3 const&, T4 const&)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(T1 const&, T2 const&, T3 const&, T4 const&)
 {}
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
-inline void ignore_unused(T1 const&, T2 const&, T3 const&, T4 const&, T5 const&)
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused(T1 const&, T2 const&, T3 const&, T4 const&, T5 const&)
 {}
 
 template <typename T1>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 template <typename T1, typename T2>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 template <typename T1, typename T2, typename T3>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 template <typename T1, typename T2, typename T3, typename T4>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
-inline void ignore_unused()
+BOOST_FORCEINLINE BOOST_CXX14_CONSTEXPR void ignore_unused()
 {}
 
 #endif

--- a/test/ignore_unused_test.cpp
+++ b/test/ignore_unused_test.cpp
@@ -6,6 +6,12 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+BOOST_CXX14_CONSTEXPR int test_fun(int a)
+{
+    boost::ignore_unused(a);
+    return 0;
+}
+
 int main()
 {
     {
@@ -58,6 +64,11 @@ int main()
         typedef int d;
         typedef int e;
         boost::ignore_unused<a, b, c, d, e>();
+    }
+
+    {
+        BOOST_CXX14_CONSTEXPR const int a = test_fun(0);
+        boost::ignore_unused(a);
     }
 
     return 0;


### PR DESCRIPTION
Add C++14 constexpr by BOOST_CXX14_CONSTEXPR.
Replace inline with BOOST_FORCEINLINE.