### PR TITLE
Disable auto_ptr support in get_pointer when BOOST_NO_AUTO_PTR is def…

### DIFF
--- a/include/boost/get_pointer.hpp
+++ b/include/boost/get_pointer.hpp
@@ -24,10 +24,14 @@ template<class T> T * get_pointer(T * p)
 
 // get_pointer(shared_ptr<T> const & p) has been moved to shared_ptr.hpp
 
+#if !defined( BOOST_NO_AUTO_PTR )
+
 template<class T> T * get_pointer(std::auto_ptr<T> const& p)
 {
     return p.get();
 }
+
+#endif
 
 #if !defined( BOOST_NO_CXX11_SMART_PTR )
 


### PR DESCRIPTION
…ined.

This is consistent with how Boost.SmartPtr handles deprecated std::auto_ptr. This way the user can disable the auto_ptr support to suppress compiler warnings.