### PR TITLE
demangle.hpp: add workaround for gabi++

### DIFF
--- a/include/boost/core/demangle.hpp
+++ b/include/boost/core/demangle.hpp
@@ -31,6 +31,11 @@
 # include <cstddef>
 #endif
 
+// Workaround: gabi++ does not define __cxa_demangle()
+#ifdef __GABIXX_CXXABI_H__
+# undef BOOST_CORE_HAS_CXXABI_H
+#endif
+
 namespace boost
 {
 
@@ -116,6 +121,8 @@ inline std::string demangle( char const * name )
 
 } // namespace boost
 
-#undef BOOST_CORE_HAS_CXXABI_H
+#ifdef BOOST_CORE_HAS_CXXABI_H
+# undef BOOST_CORE_HAS_CXXABI_H
+#endif
 
 #endif // #ifndef BOOST_CORE_DEMANGLE_HPP_INCLUDED


### PR DESCRIPTION
Hi,

Compiling [yaml-cpp](https://github.com/jbeder/yaml-cpp) for Android, I noticed that `demangle.hpp` does not compile for the mips, mips64, x86, and x86_64 targets when libc++ is used as C++ library.

`demangle.hpp` does not compile with such configuration because Android's `ndk-build` tool selects as C++ ABI for such archs [gabi++](https://android.googlesource.com/platform/ndk/+/master/sources/cxx-stl/gabi++/), which lacks `abi::__cxa_demangle()` even though `cxxabi.h` exists.

(Other architectures, e.g., arm, compile just fine because for them libc++abi is selected as C++ ABI.)

This patch detects the case in which `cxxabi.h` is provided by gabi++ and undefines `BOOST_CORE_HAS_CXXABI_H` in `demangle.hpp` such that access to `abi::__cxa_demangle()` is not attempted.

Behavior tested using the latest version of the [Android NDK](https://developer.android.com/ndk/downloads/index.html), that is, r10e. Problem also reproducible using a [minimal test case](https://github.com/bassosimone/boost-core-gabicxx-fix).

Thanks.