### PR TITLE
Suppress deprecated warning in C++11 mode GCC.

### DIFF
--- a/include/boost/get_pointer.hpp
+++ b/include/boost/get_pointer.hpp
@@ -26,10 +26,17 @@ template<class T> T * get_pointer(T * p)
 
 #if !defined( BOOST_NO_AUTO_PTR )
 
+#if defined( BOOST_GCC_CXX11 )
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 template<class T> T * get_pointer(std::auto_ptr<T> const& p)
 {
     return p.get();
 }
+#if defined( BOOST_GCC_CXX11 )
+#   pragma GCC diagnostic pop
+#endif
 
 #endif
 


### PR DESCRIPTION
This PR suppresses deprecated warning on C++11 mode GCC: [see regression test output](http://www.boost.org/development/tests/develop/output/Flast-FreeBSD10-gcc-5-1-0~gnu++11-fusion-gcc-5-1-0-warnings.html).