### PR TITLE
Enable_if_has_type

### DIFF
--- a/doc/enable_if.qbk
+++ b/doc/enable_if.qbk
@@ -304,7 +304,7 @@ depends on the template arguments of the class. Note that
 again, the second argument to `enable_if` is not needed; the
 default (`void`) is the correct value.
 
-The `enable_if_type` template is usable this scenario but instead of
+The `enable_if_has_type` template is usable this scenario but instead of
 using a type traits to enable or disable a specialization, it use a
 SFINAE context to check for the existence of a dependent type inside
 its parameter. For example, the following structure extracts a dependent
@@ -318,7 +318,7 @@ class value_type_from
 };
 
 template <class T>
-class value_type_from<T, typename enable_if_type<typename T::value_type>::type>
+class value_type_from<T, typename enable_if_has_type<typename T::value_type>::type>
 {
   typedef typename T::value_type type;
 };

--- a/doc/enable_if.qbk
+++ b/doc/enable_if.qbk
@@ -304,6 +304,26 @@ depends on the template arguments of the class. Note that
 again, the second argument to `enable_if` is not needed; the
 default (`void`) is the correct value.
 
+The `enable_if_type` template is usable this scenario but instead of
+using a type traits to enable or disable a specialization, it use a
+SFINAE context to check for the existence of a dependent type inside
+its parameter. For example, the following structure extracts a dependent
+`value_type` from T if and only if `T::value_type` exists.
+
+``
+template <class T, class Enable = void>
+class value_type_from
+{
+  typedef T type;
+};
+
+template <class T>
+class value_type_from<T, typename enable_if_type<typename T::value_type>::type>
+{
+  typedef typename T::value_type type;
+};
+``
+
 [endsect]
 
 [section Overlapping enabler conditions]

--- a/include/boost/core/enable_if.hpp
+++ b/include/boost/core/enable_if.hpp
@@ -23,6 +23,11 @@
 
 namespace boost
 {
+  template<typename T, typename R=void>
+  struct enable_if_type
+  {
+    typedef R type;
+  };
  
   template <bool B, class T = void>
   struct enable_if_c {
@@ -79,6 +84,10 @@ namespace boost {
 
   template <typename T>
   struct enable_if_does_not_work_on_this_compiler;
+
+  template<typename T, typename R=void>
+  struct enable_if_type : enable_if_does_not_work_on_this_compiler<T>
+  { };
 
   template <bool B, class T = detail::enable_if_default_T>
   struct enable_if_c : enable_if_does_not_work_on_this_compiler<T>

--- a/include/boost/core/enable_if.hpp
+++ b/include/boost/core/enable_if.hpp
@@ -24,7 +24,7 @@
 namespace boost
 {
   template<typename T, typename R=void>
-  struct enable_if_type
+  struct enable_if_has_type
   {
     typedef R type;
   };
@@ -86,7 +86,7 @@ namespace boost {
   struct enable_if_does_not_work_on_this_compiler;
 
   template<typename T, typename R=void>
-  struct enable_if_type : enable_if_does_not_work_on_this_compiler<T>
+  struct enable_if_has_type : enable_if_does_not_work_on_this_compiler<T>
   { };
 
   template <bool B, class T = detail::enable_if_default_T>

--- a/test/eif_partial_specializations.cpp
+++ b/test/eif_partial_specializations.cpp
@@ -14,7 +14,7 @@
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-using boost::enable_if_type;
+using boost::enable_if_has_type;
 using boost::enable_if_c;
 using boost::disable_if_c;
 using boost::enable_if;
@@ -55,7 +55,7 @@ class tester3
 };
 
 template <class T>
-class tester3<T, typename enable_if_type<typename T::value_type>::type>
+class tester3<T, typename enable_if_has_type<typename T::value_type>::type>
 {
   typedef typename T::value_type type;
   BOOST_STATIC_CONSTANT(bool, value = true);

--- a/test/eif_partial_specializations.cpp
+++ b/test/eif_partial_specializations.cpp
@@ -14,6 +14,7 @@
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
+using boost::enable_if_type;
 using boost::enable_if_c;
 using boost::disable_if_c;
 using boost::enable_if;
@@ -46,9 +47,28 @@ struct tester2<T, typename disable_if<is_arithmetic<T> >::type> {
   BOOST_STATIC_CONSTANT(bool, value = false);
 };
 
+template <class T, class Enable = void>
+class tester3
+{
+  typedef T type;
+  BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template <class T>
+class tester3<T, typename enable_if_type<typename T::value_type>::type>
+{
+  typedef typename T::value_type type;
+  BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+struct sample_value_type
+{
+  typedef float***& value_type;
+};
+
 int main()
 {
- 
+
   BOOST_TEST(tester<int>::value);
   BOOST_TEST(tester<double>::value);
 
@@ -60,6 +80,9 @@ int main()
 
   BOOST_TEST(!tester2<char*>::value);
   BOOST_TEST(!tester2<void*>::value);
+
+  BOOST_TEST(!tester3<char*>::value);
+  BOOST_TEST(tester3<sample_value_type>::value);
 
   return boost::report_errors();
 }


### PR DESCRIPTION
Provides an autonomous of enable_if_has_type which enable SFIANE checks on type existence.
Renamed enable_if_has_type after discussions on the Bosot dev ML.