### PR TITLE
Better detection of cxxabi header for gcc+libc++

### DIFF
--- a/include/boost/core/demangle.hpp
+++ b/include/boost/core/demangle.hpp
@@ -20,7 +20,7 @@
 // __has_include is currently supported by GCC and Clang. However GCC4.9 may have issues and
 // returns 1 for `defined( __has_include )`, while `__has_include` is actually not supported:
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
-#if (!defined( __GNUC__ ) || __GNUC__ >= 5) && defined( __has_include )
+#if (defined( __clang__ ) || !defined( __GNUC__ ) || __GNUC__ >= 5) && defined( __has_include )
 # if __has_include(<cxxabi.h>)
 #  define BOOST_CORE_HAS_CXXABI_H
 # endif

--- a/include/boost/core/demangle.hpp
+++ b/include/boost/core/demangle.hpp
@@ -17,11 +17,14 @@
 # pragma once
 #endif
 
-#if defined( __clang__ ) && defined( __has_include )
+// __has_include is currently supported by GCC and Clang. However GCC4.9 may have issues and
+// returns 1 for `defined( __has_include )`, while `__has_include` is actually not supported:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
+#if (!defined( __GNUC__ ) || __GNUC__ >= 5) && defined( __has_include )
 # if __has_include(<cxxabi.h>)
 #  define BOOST_CORE_HAS_CXXABI_H
 # endif
-#elif defined( __GLIBCXX__ ) || defined( __GLIBCPP__ )
+#elif defined( __GLIBCXX__ ) || defined( __GLIBCPP__ ) || defined( _LIBCPP_VERSION )
 # define BOOST_CORE_HAS_CXXABI_H
 #endif
 


### PR DESCRIPTION
Some of the Android related tests run GCC with libc++. On those tests abi::__cxa_demangle is not used, while it is available.
This pull request allows usage of `__has_include` for latest GCC and assumes that all the libc++ have `cxxabi.h` header.
