### PR TITLE
Define CORE_NO_CONSTEXPR_ADDRESSOF if NO_CXX11_CONSTEXPR is defined

### DIFF
--- a/include/boost/core/addressof.hpp
+++ b/include/boost/core/addressof.hpp
@@ -27,6 +27,10 @@ http://www.boost.org/LICENSE_1_0.txt)
 #endif
 
 #if defined(BOOST_CORE_HAS_BUILTIN_ADDRESSOF)
+#if defined(BOOST_NO_CXX11_CONSTEXPR)
+#define BOOST_CORE_NO_CONSTEXPR_ADDRESSOF
+#endif
+
 namespace boost {
 
 template<class T>


### PR DESCRIPTION
The test case could check for BOOST_NO_CXX11_CONSTEXPR but it makes sense for BOOST_CORE_NO_CONSTEXPR_ADDRESSOF to be defined in this case also.