### PR TITLE
Also disable addressof for r-values when possible

### DIFF
--- a/include/boost/core/addressof.hpp
+++ b/include/boost/core/addressof.hpp
@@ -262,4 +262,14 @@ addressof(T& o) BOOST_NOEXCEPT
 } /* boost */
 #endif
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+namespace boost {
+
+template<class T>
+const T* addressof(const T&&) = delete;
+
+} /* boost */
+#endif
+
 #endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,6 +14,7 @@ run addressof_test2.cpp ;
 run addressof_np_test.cpp ;
 run addressof_fn_test.cpp ;
 compile addressof_constexpr_test.cpp ;
+compile-fail addressof_fail_rvalue.cpp ;
 
 run checked_delete_test.cpp ;
 compile-fail checked_delete_fail.cpp ;

--- a/test/addressof_constexpr_test.cpp
+++ b/test/addressof_constexpr_test.cpp
@@ -1,10 +1,9 @@
 /*
 Copyright 2017 Glen Joseph Fernandes
-<glenjofe -at- gmail.com>
+(glenjofe@gmail.com)
 
-Distributed under the Boost Software
-License, Version 1.0.
-http://boost.org/LICENSE_1_0.txt
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
 */
 
 #include <boost/core/addressof.hpp>

--- a/test/addressof_fail_rvalue.cpp
+++ b/test/addressof_fail_rvalue.cpp
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include <boost/core/addressof.hpp>
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+struct type { };
+
+inline const type function()
+{
+    return type();
+}
+
+int main()
+{
+    (void)boost::addressof(function());
+}
+#else
+#error Requires rvalue references and deleted functions
+#endif


### PR DESCRIPTION
Now in C++17: `template<class T> const T* addressof(const T&&) = delete;` 