### PR TITLE
Update get_pointer to support all fancy pointers

### DIFF
--- a/include/boost/get_pointer.hpp
+++ b/include/boost/get_pointer.hpp
@@ -1,76 +1,44 @@
-// Copyright Peter Dimov and David Abrahams 2002.
-// Distributed under the Boost Software License, Version 1.0. (See
-// accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
-#ifndef GET_POINTER_DWA20021219_HPP
-#define GET_POINTER_DWA20021219_HPP
+/*
+Copyright Peter Dimov and David Abrahams 2002.
+
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef BOOST_GET_POINTER_HPP
+#define BOOST_GET_POINTER_HPP
 
 #include <boost/config.hpp>
+#include <boost/config/no_tr1/memory.hpp>
 
-// In order to avoid circular dependencies with Boost.TR1
-// we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
-// rather than including <memory> directly:
-#include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
+namespace boost {
 
-namespace boost { 
-
-// get_pointer(p) extracts a ->* capable pointer from p
-
-template<class T> T * get_pointer(T * p)
+template<class T>
+inline T*
+get_pointer(T* pointer) BOOST_NOEXCEPT
 {
-    return p;
+    return pointer;
 }
 
-// get_pointer(shared_ptr<T> const & p) has been moved to shared_ptr.hpp
-
-#if !defined( BOOST_NO_AUTO_PTR )
-
-#if defined( __GNUC__ ) && (defined( __GXX_EXPERIMENTAL_CXX0X__ ) || (__cplusplus >= 201103L))
-#if defined( BOOST_GCC )
-#if BOOST_GCC >= 40600
-#define BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS
-#endif // BOOST_GCC >= 40600
-#elif defined( __clang__ ) && defined( __has_warning )
-#if __has_warning("-Wdeprecated-declarations")
-#define BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS
-#endif // __has_warning("-Wdeprecated-declarations")
-#endif
-#endif // defined( __GNUC__ ) && (defined( __GXX_EXPERIMENTAL_CXX0X__ ) || (__cplusplus >= 201103L))
-
-#if defined( BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS )
-// Disable libstdc++ warnings about std::auto_ptr being deprecated in C++11 mode
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#define BOOST_CORE_DETAIL_DISABLED_DEPRECATED_WARNINGS
-#endif
-
-template<class T> T * get_pointer(std::auto_ptr<T> const& p)
+#if !defined(BOOST_NO_CXX11_ALLOCATOR)
+template<class T>
+inline typename std::pointer_traits<T>::element_type*
+get_pointer(const T& pointer) BOOST_NOEXCEPT
 {
-    return p.get();
+    return boost::get_pointer(pointer.operator->());
 }
-
-#if defined( BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS )
-#pragma GCC diagnostic pop
-#undef BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS
+#else
+template<class T>
+inline typename T::element_type*
+get_pointer(const T& pointer) BOOST_NOEXCEPT
+{
+    return pointer.get();
+}
 #endif
 
-#endif // !defined( BOOST_NO_AUTO_PTR )
-
-#if !defined( BOOST_NO_CXX11_SMART_PTR )
-
-template<class T> T * get_pointer( std::unique_ptr<T> const& p )
-{
-    return p.get();
-}
-
-template<class T> T * get_pointer( std::shared_ptr<T> const& p )
-{
-    return p.get();
-}
+} /* boost */
 
 #endif
-
-} // namespace boost
-
-#endif // GET_POINTER_DWA20021219_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -61,6 +61,7 @@ run sp_typeinfo_test.cpp : : : <rtti>off : sp_typeinfo_test_no_rtti ;
 run visit_each_test.cpp ;
 
 run get_pointer_test.cpp ;
+run get_pointer_fancy_test.cpp ;
 
 run lightweight_test_test.cpp ;
 run lightweight_test_test.cpp : : : <exception-handling>off : lightweight_test_test_no_except ;

--- a/test/get_pointer_fancy_test.cpp
+++ b/test/get_pointer_fancy_test.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/get_pointer.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#if !defined(BOOST_NO_CXX11_ALLOCATOR)
+template<class T>
+class Fancy {
+public:
+    Fancy(T* value)
+        : value_(value) { }
+
+    T* operator->() const {
+        return value_;
+    }
+
+private:
+    T* value_;
+};
+
+template<class T>
+class Fancier {
+public:
+    typedef typename std::pointer_traits<T>::element_type element_type;
+
+    Fancier(T value)
+        : value_(value) { }
+
+    T operator->() const {
+        return value_;
+    }
+
+private:
+    T value_;
+};
+
+int main()
+{
+    int i = 0;
+    Fancy<int> p(&i);
+    BOOST_TEST(boost::get_pointer(p) == &i);
+    Fancier<Fancy<int> > q(p);
+    BOOST_TEST(boost::get_pointer(q) == &i);
+    return boost::report_errors();
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif


### PR DESCRIPTION
This is the alternative pull request which updates `get_pointer` instead of adding `to_raw_pointer`. The other pull request is #31 which adds `to_raw_pointer` to Core.