### PR TITLE
address_of.hpp: Fix namespace ambiguity

### DIFF
--- a/include/boost/core/addressof.hpp
+++ b/include/boost/core/addressof.hpp
@@ -127,9 +127,9 @@ addressof(T& o) BOOST_NOEXCEPT
 {
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x610)) || \
     BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5120)
-    return detail::address_of<T>::get(o, 0);
+    return boost::detail::address_of<T>::get(o, 0);
 #else
-    return detail::address_of<T>::get(detail::addressof_ref<T>(o), 0);
+    return boost::detail::address_of<T>::get(boost::detail::addressof_ref<T>(o), 0);
 #endif
 }
 


### PR DESCRIPTION
I'm seeing compiler errors with vc12, when testing serialization of Boost.Multiprecision types - there is ambiguity between boost::detail and boost::multiprecision::detail.  I assume the error occurs for serialization of any type that has it's own detail namespace.  The fix is trivially to qualify the use of "detail::".