### PR TITLE
print the qualified type

### DIFF
--- a/include/boost/core/lightweight_test_trait.hpp
+++ b/include/boost/core/lightweight_test_trait.hpp
@@ -20,6 +20,7 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/core/is_same.hpp>
+#include <boost/config.hpp>
 
 namespace boost
 {
@@ -53,7 +54,7 @@ template<class T> inline bool test_trait_same_impl_( T )
 }
 
 template <class T>
-struct test_trait_stream_type {
+struct test_trait_print_type {
   static void stream() {
     BOOST_LIGHTWEIGHT_TEST_OSTREAM
       << boost::core::demangled_name( BOOST_CORE_TYPEID(T) );
@@ -61,34 +62,36 @@ struct test_trait_stream_type {
 };
 
 template <class T>
-struct test_trait_stream_type<T const>  {
+struct test_trait_print_type<T const>  {
   static void stream() {
-    test_trait_stream_type<T>::stream();
+    test_trait_print_type<T>::stream();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << " const"; }
 };
 
 template <class T>
-struct test_trait_stream_type<T volatile> {
+struct test_trait_print_type<T volatile> {
   static void stream() {
-    test_trait_stream_type<T>::stream();
+    test_trait_print_type<T>::stream();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << " volatile"; }
 };
 
 template <class T>
-struct test_trait_stream_type<T&>  {
+struct test_trait_print_type<T&>  {
   static void stream() {
-    test_trait_stream_type<T>::stream();
+    test_trait_print_type<T>::stream();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << "&";
   }
 };
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 template <class T>
-struct test_trait_stream_type<T*>  {
+struct test_trait_print_type<T&&>  {
   static void stream() {
-    test_trait_stream_type<T>::stream();
-    BOOST_LIGHTWEIGHT_TEST_OSTREAM << "*";
+    test_trait_print_type<T>::stream();
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM << "&&";
   }
 };
+#endif
 
 template<class T1, class T2> inline void test_trait_same_impl( char const * types,
   boost::core::is_same<T1, T2> same, char const * file, int line, char const * function )
@@ -104,11 +107,11 @@ template<class T1, class T2> inline void test_trait_same_impl( char const * type
             << " failed in function '" << function
             << "' ('";
 
-        test_trait_stream_type<T1>::stream();
+        test_trait_print_type<T1>::stream();
 
         BOOST_LIGHTWEIGHT_TEST_OSTREAM << "' != '";
 
-        test_trait_stream_type<T2>::stream();
+        test_trait_print_type<T2>::stream();
 
         BOOST_LIGHTWEIGHT_TEST_OSTREAM << "')" << std::endl;
 

--- a/include/boost/core/lightweight_test_trait.hpp
+++ b/include/boost/core/lightweight_test_trait.hpp
@@ -17,10 +17,10 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 
-#include <boost/config.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/core/is_same.hpp>
+#include <boost/config.hpp>
 
 namespace boost
 {

--- a/include/boost/core/lightweight_test_trait.hpp
+++ b/include/boost/core/lightweight_test_trait.hpp
@@ -52,6 +52,44 @@ template<class T> inline bool test_trait_same_impl_( T )
     return T::value;
 }
 
+template <class T>
+struct test_trait_stream_type {
+  static void stream() {
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM
+      << boost::core::demangled_name( BOOST_CORE_TYPEID(T) );
+  }
+};
+
+template <class T>
+struct test_trait_stream_type<T const>  {
+  static void stream() {
+    test_trait_stream_type<T>::stream();
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM << " const"; }
+};
+
+template <class T>
+struct test_trait_stream_type<T volatile> {
+  static void stream() {
+    test_trait_stream_type<T>::stream();
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM << " volatile"; }
+};
+
+template <class T>
+struct test_trait_stream_type<T&>  {
+  static void stream() {
+    test_trait_stream_type<T>::stream();
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM << "&";
+  }
+};
+
+template <class T>
+struct test_trait_stream_type<T*>  {
+  static void stream() {
+    test_trait_stream_type<T>::stream();
+    BOOST_LIGHTWEIGHT_TEST_OSTREAM << "*";
+  }
+};
+
 template<class T1, class T2> inline void test_trait_same_impl( char const * types,
   boost::core::is_same<T1, T2> same, char const * file, int line, char const * function )
 {
@@ -64,9 +102,15 @@ template<class T1, class T2> inline void test_trait_same_impl( char const * type
         BOOST_LIGHTWEIGHT_TEST_OSTREAM
             << file << "(" << line << "): test 'is_same<" << types << ">'"
             << " failed in function '" << function
-            << "' ('" << boost::core::demangled_name( BOOST_CORE_TYPEID(T1) )
-            << "' != '" << boost::core::demangled_name( BOOST_CORE_TYPEID(T2) ) << "')"
-            << std::endl;
+            << "' ('";
+
+        test_trait_stream_type<T1>::stream();
+
+        BOOST_LIGHTWEIGHT_TEST_OSTREAM << "' != '";
+
+        test_trait_stream_type<T2>::stream();
+
+        BOOST_LIGHTWEIGHT_TEST_OSTREAM << "')" << std::endl;
 
         ++test_results().errors();
     }

--- a/include/boost/core/lightweight_test_trait.hpp
+++ b/include/boost/core/lightweight_test_trait.hpp
@@ -17,10 +17,10 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 
+#include <boost/config.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/core/is_same.hpp>
-#include <boost/config.hpp>
 
 namespace boost
 {
@@ -55,7 +55,7 @@ template<class T> inline bool test_trait_same_impl_( T )
 
 template <class T>
 struct test_trait_print_type {
-  static void stream() {
+  static void print() {
     BOOST_LIGHTWEIGHT_TEST_OSTREAM
       << boost::core::demangled_name( BOOST_CORE_TYPEID(T) );
   }
@@ -63,22 +63,22 @@ struct test_trait_print_type {
 
 template <class T>
 struct test_trait_print_type<T const>  {
-  static void stream() {
-    test_trait_print_type<T>::stream();
+  static void print() {
+    test_trait_print_type<T>::print();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << " const"; }
 };
 
 template <class T>
 struct test_trait_print_type<T volatile> {
-  static void stream() {
-    test_trait_print_type<T>::stream();
+  static void print() {
+    test_trait_print_type<T>::print();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << " volatile"; }
 };
 
 template <class T>
 struct test_trait_print_type<T&>  {
-  static void stream() {
-    test_trait_print_type<T>::stream();
+  static void print() {
+    test_trait_print_type<T>::print();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << "&";
   }
 };
@@ -86,8 +86,8 @@ struct test_trait_print_type<T&>  {
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 template <class T>
 struct test_trait_print_type<T&&>  {
-  static void stream() {
-    test_trait_print_type<T>::stream();
+  static void print() {
+    test_trait_print_type<T>::print();
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << "&&";
   }
 };
@@ -107,11 +107,11 @@ template<class T1, class T2> inline void test_trait_same_impl( char const * type
             << " failed in function '" << function
             << "' ('";
 
-        test_trait_print_type<T1>::stream();
+        test_trait_print_type<T1>::print();
 
         BOOST_LIGHTWEIGHT_TEST_OSTREAM << "' != '";
 
-        test_trait_print_type<T2>::stream();
+        test_trait_print_type<T2>::print();
 
         BOOST_LIGHTWEIGHT_TEST_OSTREAM << "')" << std::endl;
 

--- a/test/lightweight_test_test5.cpp
+++ b/test/lightweight_test_test5.cpp
@@ -8,8 +8,8 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/core/lightweight_test_trait.hpp>
 #include <boost/config.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 struct X
 {

--- a/test/lightweight_test_test5.cpp
+++ b/test/lightweight_test_test5.cpp
@@ -9,6 +9,7 @@
 //
 
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/config.hpp>
 
 struct X
 {
@@ -25,15 +26,17 @@ int main()
     typedef X& XR;
     typedef X* XP;
     typedef X** XPP;
-    typedef X const XC;
     typedef X const& XCR;
     typedef X const* XCP;
     typedef X const* const XCPC;
     BOOST_TEST_TRAIT_SAME(X, XR);
-    BOOST_TEST_TRAIT_SAME(X, XP);
     BOOST_TEST_TRAIT_SAME(XP, XPP);
     BOOST_TEST_TRAIT_SAME(XCR, XR);
     BOOST_TEST_TRAIT_SAME(XCP, XCPC);
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    typedef X&& XRR;
+    BOOST_TEST_TRAIT_SAME(XR, XRR);
+#endif
     BOOST_TEST_TRAIT_SAME(char[1], char[2]);
     BOOST_TEST_TRAIT_SAME(char[1], char[]);
     BOOST_TEST_TRAIT_SAME(char[1], char*);

--- a/test/lightweight_test_test5.cpp
+++ b/test/lightweight_test_test5.cpp
@@ -22,6 +22,18 @@ template<class T1, class T2> struct Y
 
 int main()
 {
+    typedef X& XR;
+    typedef X* XP;
+    typedef X** XPP;
+    typedef X const XC;
+    typedef X const& XCR;
+    typedef X const* XCP;
+    typedef X const* const XCPC;
+    BOOST_TEST_TRAIT_SAME(X, XR);
+    BOOST_TEST_TRAIT_SAME(X, XP);
+    BOOST_TEST_TRAIT_SAME(XP, XPP);
+    BOOST_TEST_TRAIT_SAME(XCR, XR);
+    BOOST_TEST_TRAIT_SAME(XCP, XCPC);
     BOOST_TEST_TRAIT_SAME(char[1], char[2]);
     BOOST_TEST_TRAIT_SAME(char[1], char[]);
     BOOST_TEST_TRAIT_SAME(char[1], char*);
@@ -33,5 +45,5 @@ int main()
     BOOST_TEST_TRAIT_SAME(X::type, Y<float, int>::type);
     BOOST_TEST_TRAIT_SAME(Y<int, float>, Y<int, double>);
 
-    return boost::report_errors() == 10;
+    return boost::report_errors() == 15;
 }

--- a/test/lightweight_test_test5.cpp
+++ b/test/lightweight_test_test5.cpp
@@ -8,8 +8,8 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/config.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/config.hpp>
 
 struct X
 {


### PR DESCRIPTION
`BOOST_TEST_TRAIT_SAME(T, T const)` produced the right result, but the wrong error message. It used to say
```
'int main()' ('T' != 'T')
```
This patch prints the correctly qualified type name
```
'int main()' ('T' != 'T const')
```