### PR TITLE
fix warning of "unescapted special character"

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -49,7 +49,7 @@ boostbook standalone
     <xsl:param>boost.root=../../../..
     <xsl:param>generate.section.toc.level=1
     <xsl:param>toc.max.depth=1
-    <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/libs/core/doc/html
+    <format>pdf:<xsl:param>boost.url.prefix=http\://www.boost.org/doc/libs/release/libs/core/doc/html
   ;
 
 ###############################################################################


### PR DESCRIPTION
Running b2 in the doc folder gave the warning:
```
Jamfile.v2:52: Unescaped special character in argument <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/libs/core/doc/html
```
This patch fixes the warning.