### PR TITLE
Add class version

### DIFF
--- a/include/boost/core/class_version.hpp
+++ b/include/boost/core/class_version.hpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2019 Hans Dembinski
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/core/doc/html/core/version.html for documentation.
+//
+#ifndef BOOST_CORE_CLASS_VERSION_HPP
+#define BOOST_CORE_CLASS_VERSION_HPP
+
+#include <boost/config.hpp>
+
+namespace boost {
+
+namespace core {
+template <int N>
+struct int_c {
+  typedef int value_type;
+  enum { value = N };
+  operator value_type() const { return N; }
+};
+} /* core */
+
+namespace serialization {
+
+// default implementation, to be specialized by users as needed
+template<class T>
+struct version : core::int_c<0> {};
+
+} /* serialization */
+
+} /* boost */
+
+#define BOOST_CLASS_VERSION(T, N) \
+namespace boost { \
+namespace serialization { \
+template <> struct version<T> : core::int_c<N> {}; \
+} /* serialization */ \
+} /* boost */
+
+#endif

--- a/include/boost/core/class_version.hpp
+++ b/include/boost/core/class_version.hpp
@@ -26,7 +26,7 @@ namespace serialization {
 
 // default implementation, to be specialized by users as needed
 template<class T>
-struct version : core::int_c<0> {};
+struct version : ::boost::core::int_c<0> {};
 
 } /* serialization */
 
@@ -35,7 +35,7 @@ struct version : core::int_c<0> {};
 #define BOOST_CLASS_VERSION(T, N) \
 namespace boost { \
 namespace serialization { \
-template <> struct version<T> : core::int_c<N> {}; \
+template <> struct version<T> : ::boost::core::int_c<N> {}; \
 } /* serialization */ \
 } /* boost */
 

--- a/include/boost/core/class_version.hpp
+++ b/include/boost/core/class_version.hpp
@@ -23,7 +23,7 @@ struct int_c {
 
 } /* core */
 
-// default implementation, to be specialized by users as needed, must be top-level
+// default implementation, to be specialized by users as needed
 template <class T>
 struct class_version : ::boost::core::int_c<0> {};
 
@@ -39,7 +39,7 @@ struct version : ::boost::class_version<T> {};
 
 #define BOOST_CLASS_VERSION(T, N)                                          \
 namespace boost {                                                          \
-template <> struct ::boost::class_version<T> : ::boost::core::int_c<N> {}; \
+template <> struct class_version<T> : ::boost::core::int_c<N> {}; \
 }
 
 #endif

--- a/include/boost/core/class_version.hpp
+++ b/include/boost/core/class_version.hpp
@@ -12,31 +12,34 @@
 #include <boost/config.hpp>
 
 namespace boost {
-
 namespace core {
+
 template <int N>
 struct int_c {
   typedef int value_type;
   enum { value = N };
   operator value_type() const { return N; }
 };
+
 } /* core */
+
+// default implementation, to be specialized by users as needed, must be top-level
+template <class T>
+struct class_version : ::boost::core::int_c<0> {};
 
 namespace serialization {
 
-// default implementation, to be specialized by users as needed
+// for backward compatibility
 template<class T>
-struct version : ::boost::core::int_c<0> {};
+struct version : ::boost::class_version<T> {};
 
 } /* serialization */
 
 } /* boost */
 
-#define BOOST_SERIALIZATION_VERSION(T, N) \
-namespace boost { \
-namespace serialization { \
-template <> struct version<T> : ::boost::core::int_c<N> {}; \
-} /* serialization */ \
-} /* boost */
+#define BOOST_CLASS_VERSION(T, N)                                          \
+namespace boost {                                                          \
+template <> struct ::boost::class_version<T> : ::boost::core::int_c<N> {}; \
+}
 
 #endif

--- a/include/boost/core/class_version.hpp
+++ b/include/boost/core/class_version.hpp
@@ -32,7 +32,7 @@ struct version : ::boost::core::int_c<0> {};
 
 } /* boost */
 
-#define BOOST_CLASS_VERSION(T, N) \
+#define BOOST_SERIALIZATION_VERSION(T, N) \
 namespace boost { \
 namespace serialization { \
 template <> struct version<T> : ::boost::core::int_c<N> {}; \

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -152,6 +152,7 @@ run alloc_construct_throws_test.cpp ;
 run alloc_construct_cxx11_test.cpp ;
 
 run nvp_test.cpp ;
+run class_version_test.cpp ;
 
 lib lib_typeid : lib_typeid.cpp : <link>shared:<define>LIB_TYPEID_DYN_LINK=1 ;
 

--- a/test/class_version_test.cpp
+++ b/test/class_version_test.cpp
@@ -20,23 +20,22 @@ struct foo {};
 struct bar {};
 
 namespace boost {
-namespace serialization {
-template <> struct version<bar> : core::int_c<2> {};  
-}
+template <> struct class_version<bar> : core::int_c<2> {};
 }
 
 void test_version()
 {
-    BOOST_TEST_EQ(boost::serialization::version<foo>::value, 0);
+    BOOST_TEST_EQ(boost::class_version<foo>::value, 0);
+    BOOST_TEST_EQ(boost::class_version<bar>::value, 2);
     BOOST_TEST_EQ(boost::serialization::version<bar>::value, 2);
 }
 
 struct baz {};
-BOOST_SERIALIZATION_VERSION(baz, 3);
+BOOST_CLASS_VERSION(baz, 3);
 
 void test_macro()
 {
-    BOOST_TEST_EQ(boost::serialization::version<baz>::value, 3);
+    BOOST_TEST_EQ(boost::class_version<baz>::value, 3);
 }
 
 int main()

--- a/test/class_version_test.cpp
+++ b/test/class_version_test.cpp
@@ -20,21 +20,23 @@ struct foo {};
 struct bar {};
 
 namespace boost {
-template <> struct version<bar> : core::int_c<2> {};
+namespace serialization {
+template <> struct version<bar> : core::int_c<2> {};  
+}
 }
 
 void test_version()
 {
-    BOOST_TEST_EQ(boost::version<foo>::value, 0);
-    BOOST_TEST_EQ(boost::version<bar>::value, 2);
+    BOOST_TEST_EQ(boost::serialization::version<foo>::value, 0);
+    BOOST_TEST_EQ(boost::serialization::version<bar>::value, 2);
 }
 
 struct baz {};
-BOOST_CLASS_VERSION(baz, 3);
+BOOST_SERIALIZATION_VERSION(baz, 3);
 
 void test_macro()
 {
-    BOOST_TEST_EQ(boost::version<baz>::value, 3);
+    BOOST_TEST_EQ(boost::serialization::version<baz>::value, 3);
 }
 
 int main()

--- a/test/class_version_test.cpp
+++ b/test/class_version_test.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2019 Hans Dembinski
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/core/doc/html/core/version.html for documentation.
+//
+#include <boost/core/class_version.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+void test_int_c()
+{
+    typedef boost::core::int_c<2> two;
+    char a[two::value];
+    BOOST_TEST_EQ(sizeof(a), 2);
+}
+
+struct foo {};
+struct bar {};
+
+namespace boost {
+template <> struct version<bar> : core::int_c<2> {};
+}
+
+void test_version()
+{
+    BOOST_TEST_EQ(boost::version<foo>::value, 0);
+    BOOST_TEST_EQ(boost::version<bar>::value, 2);
+}
+
+struct baz {};
+BOOST_CLASS_VERSION(baz, 3);
+
+void test_macro()
+{
+    BOOST_TEST_EQ(boost::version<baz>::value, 3);
+}
+
+int main()
+{
+    test_int_c();
+    test_version();
+    test_macro();
+    return boost::report_errors();
+}


### PR DESCRIPTION
nvp was added to core, which is great to write serialize functions that do not depend directly on boost::serialization. but we also need boost::serialization::version in core, which is needed to inform boost serialization that the serialization format has changed.

The following patch has a simple implementation and some unit tests, but no documentation. There is some issue with the name. I followed the example of nvp and pulled serialization::version into the boost namespace, which yields boost::version. I would prefer if it was called boost::class_version, but I don't know how to make a templated alias without C++11 support.