### PR TITLE
Implement allocator utilities

### DIFF
--- a/doc/allocator_access.qbk
+++ b/doc/allocator_access.qbk
@@ -1,0 +1,244 @@
+[/
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+]
+
+[section Allocator Access]
+
+[simplesect Authors]
+
+* Glen Fernandes
+
+[endsimplesect]
+
+[section Overview]
+
+The header `<boost/core/allocator_access.hpp>` provides the class and function
+templates to simplify allocator use. It provides the same functionality as the
+C++ standard library `std::allocator_traits` but with individual templates for
+each allocator feature.
+
+This implementation supports C++03 and above. These facilities also simplify
+existing libraries by avoiding having to check for `BOOST_NO_CXX11_ALLOCATOR`
+and conditionally use `std::allocator_traits`.
+
+[endsect]
+
+[section Examples]
+
+The following example shows these utilities used in the definition of
+an allocator-aware container class:
+
+```
+template<class T, class A = boost::default_allocator<T> >
+class container
+    : boost::empty_value<typename boost::allocator_rebind<A, T>::type> {
+public:
+    typedef T value_type;
+    typedef A allocator_type;
+    typedef typename boost::allocator_size_type<A>::type size_type;
+    typedef typename boost::allocator_difference_type<A>::type difference_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef typename boost::allocator_pointer<A>::type pointer;
+    typedef typename boost::allocator_const_pointer<A>::type const_pointer;
+    // ...
+};
+```
+
+In C++11 or above, aliases such as `boost::allocator_pointer_t<A>` can be used
+instead of `typename boost::allocator_pointer<A>::type`.
+
+[endsect]
+
+[section Reference]
+
+```
+namespace boost {
+
+template<class A>
+struct allocator_value_type;
+
+template<class A>
+using allocator_value_type_t = typename allocator_value_type<A>::type;
+
+template<class A>
+struct allocator_pointer;
+
+template<class A>
+using allocator_pointer_t = typename allocator_pointer<A>::type;
+
+template<class A>
+struct allocator_const_pointer;
+
+template<class A>
+using allocator_const_pointer_t = typename allocator_const_pointer<A>::type;
+
+template<class A>
+struct allocator_void_pointer;
+
+template<class A>
+using allocator_void_pointer_t = typename allocator_void_pointer<A>::type;
+
+template<class A>
+struct allocator_const_void_pointer;
+
+template<class A>
+using allocator_const_void_pointer_t =
+    typename allocator_const_void_pointer<A>::type;
+
+template<class A>
+struct allocator_difference_type;
+
+template<class A>
+using allocator_difference_type_t =
+    typename allocator_difference_type<A>::type;
+
+template<class A>
+struct allocator_size_type;
+
+template<class A>
+using allocator_size_type_t = typename allocator_size_type<A>::type;
+
+template<class A>
+struct allocator_propagate_on_container_copy_assignment;
+
+template<class A>
+using allocator_propagate_on_container_copy_assignment_t =
+    typename allocator_propagate_on_container_copy_assignment<A>::type;
+
+template<class A>
+struct allocator_propagate_on_container_move_assignment;
+
+template<class A>
+using allocator_propagate_on_container_move_assignment_t =
+    typename allocator_propagate_on_container_move_assignment<A>::type;
+
+template<class A>
+struct allocator_propagate_on_container_swap;
+
+template<class A>
+using allocator_propagate_on_container_swap_t =
+    typename allocator_propagate_on_container_swap<A>::type;
+
+template<class A>
+struct allocator_is_always_equal;
+
+template<class A>
+using allocator_is_always_equal_t =
+    typename allocator_is_always_equal<A>::type;
+
+template<class A, class T>
+struct allocator_rebind;
+
+template<class A, class T>
+using allocator_rebind_t = typename allocator_rebind<A, T>::type;
+
+template<class A>
+allocator_pointer_t<A> allocator_allocate(A& a, allocator_size_type_t<A> n);
+
+template<class A>
+allocator_pointer_t<A> allocator_allocate(A& a, allocator_size_type_t<A> n,
+    allocator_const_void_pointer_t<A> hint);
+
+template<class A>
+void allocator_deallocate(A& a, allocator_pointer_t<A> p,
+    allocator_size_type_t<A> n);
+
+template<class A, class T, class... Args>
+void allocator_construct(A& a, T*p, Args&&... args);
+
+template<class A, class T>
+void allocator_destroy(A& a, T* p);
+
+template<class A>
+allocator_size_type_t<A> allocator_max_size(const A& a);
+
+template<class A>
+A allocator_select_on_container_copy_construction(const A& a);
+
+} // boost
+```
+
+[section Types]
+
+[variablelist
+[[`template<class A> struct allocator_value_type;`]
+[The member `type` is `A::value_type`.]]
+[[`template<class A> struct allocator_pointer;`]
+[The member `type` is `A::pointer` if valid, otherwise `A::value_type*`.]]
+[[`template<class A> struct allocator_const_pointer;`]
+[The member `type` is `A::const_pointer` if valid, otherwise
+`pointer_traits<allocator_pointer_t<A> >::rebind<const
+allocator_value_type_t<A> >`.]]
+[[`template<class A> struct allocator_void_pointer;`]
+[The member `type` is `A::void_pointer` if valid, otherwise
+`pointer_traits<allocator_pointer_t<A> >::rebind<void>`.]]
+[[`template<class A> struct allocator_const_void_pointer;`]
+[The member `type` is `A::const_void_pointer` if valid, otherwise
+`pointer_traits<allocator_pointer_t<A> >::rebind<const void>`.]]
+[[`template<class A> struct allocator_difference_type;`]
+[The member `type` is `A::difference_type` if valid, otherwise
+`pointer_traits<allocator_pointer_t<A> >::difference_type`.]]
+[[`template<class A> struct allocator_size_type;`]
+[The member `type` is `A::size_type` if valid, otherwise
+`std::make_unsigned_t<allocator_difference_type_t<A> >`.]]
+[[`template<class A> struct allocator_propagate_on_container_copy_assignment;`]
+[The member `type` is `A::propagate_on_container_copy_assignment` if valid,
+otherwise `std::false_type`.]]
+[[`template<class A> struct allocator_propagate_on_container_move_assignment;`]
+[The member `type` is `A::propagate_on_container_move_assignment` if valid,
+otherwise `std::false_type`.]]
+[[`template<class A> struct allocator_propagate_on_container_swap;`]
+[The member `type` is `A::propagate_on_container_swap` if valid, otherwise
+`std::false_type`.]]
+[[`template<class A> struct allocator_is_always_equal;`]
+[The member `type` is `A::is_always_equal` if valid, otherwise
+`std::is_empty<A>::type`.]]
+[[`template<class A, class T> struct allocator_rebind;`]
+[The member `type` is `A::rebind<T>::other` if valid, otherwise `A<T, Args>`
+if this `A` is `A<U, Args>`.]]]
+
+[endsect]
+
+[section Functions]
+
+[variablelist
+[[`template<class A>
+allocator_pointer_t<A> allocator_allocate(A& a, allocator_size_type_t<A> n);`]
+[Calls `a.allcoate(n)`.]]
+[[`template<class A> allocator_pointer_t<A> allocator_allocate(A& a,
+allocator_size_type_t<A> n, allocator_const_void_pointer_t<A> hint);`]
+[Calls `a.allocate(n, hint)` if valid, otherwise calls `a.allocate(n)`.]]
+[[`template<class A> void allocator_deallocate(A& a, allocator_pointer_t<A> p,
+allocator_size_type_t<A> n);`]
+[Calls `a.deallocate(p, n)`.]]
+[[`template<class A, class T, class... Args>
+void allocator_construct(A& a, T*p, Args&&... args);`]
+[Calls `a.construct(p, std::forward<Args>(args)...)` if valid, otherwise calls
+`::new(static_cast<void*>(p)) T(std::forward<Args>(args)...)`.]]
+[[`template<class A, class T> void allocator_destroy(A& a, T* p);`]
+[Calls `a.destroy(p)` if valid, otherwise calls `p->~T()`.]]
+[[`template<class A> allocator_size_type_t<A> allocator_max_size(const A& a);`]
+[Returns `a.max_size()` if valid, otehrwise returns
+`std::numeric_limits<allocator_size_type_t<A> >::max() /
+sizeof(A::value_type)`.]]
+[[`template<class A> A allocator_select_on_container_copy_construction(const
+A& a);`]
+[Returns `a.select_on_container_copy_construction()` if valid, otherwise
+returns `a`.]]]
+
+[endsect]
+
+[endsect]
+
+[section Acknowledgments]
+
+Glen Fernandes implemented the allocator access utilities.
+
+[endsect]
+
+[endsect]

--- a/doc/core.qbk
+++ b/doc/core.qbk
@@ -39,6 +39,7 @@ criteria for inclusion is that the utility component be:
 [endsect]
 
 [include addressof.qbk]
+[include allocator_access.qbk]
 [include alloc_construct.qbk]
 [include checked_delete.qbk]
 [include default_allocator.qbk]

--- a/include/boost/core/allocator_access.hpp
+++ b/include/boost/core/allocator_access.hpp
@@ -1,0 +1,545 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef BOOST_CORE_ALLOCATOR_ACCESS_HPP
+#define BOOST_CORE_ALLOCATOR_ACCESS_HPP
+
+#include <boost/core/pointer_traits.hpp>
+#include <limits>
+#include <new>
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#include <type_traits>
+#endif
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#include <utility>
+#endif
+
+#if !defined(BOOST_NO_CXX11_DECLTYPE) && \
+    !defined(BOOST_NO_SFINAE_EXPR) && \
+    (!defined(BOOST_MSVC) || BOOST_MSVC >= 1910)
+#define BOOST_CORE_ALLOCATOR_DETECTION
+#endif
+
+namespace boost {
+
+template<class A>
+struct allocator_value_type {
+    typedef typename A::value_type type;
+};
+
+namespace detail {
+
+template<class>
+struct alloc_void {
+    typedef void type;
+};
+
+} /* detail */
+
+template<class A, class = void>
+struct allocator_pointer {
+    typedef typename A::value_type* type;
+};
+
+template<class A>
+struct allocator_pointer<A,
+    typename detail::alloc_void<typename A::pointer>::type> {
+    typedef typename A::pointer type;
+};
+
+template<class A, class = void>
+struct allocator_const_pointer {
+    typedef typename pointer_traits<typename
+        allocator_pointer<A>::type>::template
+            rebind_to<const typename A::value_type>::type type;
+};
+
+template<class A>
+struct allocator_const_pointer<A,
+    typename detail::alloc_void<typename A::const_pointer>::type> {
+    typedef typename A::const_pointer type;
+};
+
+template<class A, class = void>
+struct allocator_void_pointer {
+     typedef typename pointer_traits<typename
+        allocator_pointer<A>::type>::template
+            rebind_to<void>::type type;
+};
+
+template<class A>
+struct allocator_void_pointer<A,
+    typename detail::alloc_void<typename A::void_pointer>::type> {
+    typedef typename A::void_pointer type;
+};
+
+template<class A, class = void>
+struct allocator_const_void_pointer {
+     typedef typename pointer_traits<typename
+        allocator_pointer<A>::type>::template
+            rebind_to<const void>::type type;
+};
+
+template<class A>
+struct allocator_const_void_pointer<A,
+    typename detail::alloc_void<typename A::const_void_pointer>::type> {
+    typedef typename A::const_void_pointer type;
+};
+
+template<class A, class = void>
+struct allocator_difference_type {
+    typedef typename pointer_traits<typename
+        allocator_pointer<A>::type>::difference_type type;
+};
+
+template<class A>
+struct allocator_difference_type<A,
+    typename detail::alloc_void<typename A::difference_type>::type> {
+    typedef typename A::difference_type type;
+};
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+template<class A, class = void>
+struct allocator_size_type {
+    typedef typename std::make_unsigned<typename
+        allocator_difference_type<A>::type>::type type;
+};
+
+template<class A>
+struct allocator_size_type<A,
+    typename detail::alloc_void<typename A::size_type>::type> {
+    typedef typename A::size_type type;
+};
+#else
+template<class A>
+struct allocator_size_type {
+    typedef typename A::size_type type;
+};
+#endif
+
+namespace detail {
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+typedef std::false_type alloc_false_type;
+#else
+struct alloc_false_type {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+#endif
+
+} /* detail */
+
+template<class A, class = void>
+struct allocator_propagate_on_container_copy_assignment {
+    typedef detail::alloc_false_type type;
+};
+
+template<class A>
+struct allocator_propagate_on_container_copy_assignment<A,
+    typename detail::alloc_void<typename
+        A::propagate_on_container_copy_assignment>::type> {
+    typedef typename A::propagate_on_container_copy_assignment type;
+};
+
+template<class A, class = void>
+struct allocator_propagate_on_container_move_assignment {
+    typedef detail::alloc_false_type type;
+};
+
+template<class A>
+struct allocator_propagate_on_container_move_assignment<A,
+    typename detail::alloc_void<typename
+        A::propagate_on_container_move_assignment>::type> {
+    typedef typename A::propagate_on_container_move_assignment type;
+};
+
+template<class A, class = void>
+struct allocator_propagate_on_container_swap {
+    typedef detail::alloc_false_type type;
+};
+
+template<class A>
+struct allocator_propagate_on_container_swap<A,
+    typename detail::alloc_void<typename
+        A::propagate_on_container_swap>::type> {
+    typedef typename A::propagate_on_container_swap type;
+};
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+template<class A, class = void>
+struct allocator_is_always_equal {
+    typedef typename std::is_empty<A>::type type;
+};
+#else
+template<class A, class = void>
+struct allocator_is_always_equal {
+    typedef typename detail::alloc_false_type type;
+};
+#endif
+
+template<class A>
+struct allocator_is_always_equal<A,
+    typename detail::alloc_void<typename A::is_always_equal>::type> {
+    typedef typename A::is_always_equal type;
+};
+
+namespace detail {
+
+template<class, class>
+struct alloc_to { };
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<template<class, class...> class A, class T, class U, class... V>
+struct alloc_to<A<U, V...>, T> {
+    typedef A<T, V...> type;
+};
+#else
+template<template<class> class A, class T, class U>
+struct alloc_to<A<U>, T> {
+    typedef A<T> type;
+};
+
+template<template<class, class> class A, class T, class U1, class U2>
+struct alloc_to<A<U1, U2>, T> {
+    typedef A<T, U2> type;
+};
+
+template<template<class, class, class> class A, class T, class U1, class U2,
+    class U3>
+struct alloc_to<A<U1, U2, U3>, T> {
+    typedef A<T, U2, U3> type;
+};
+#endif
+
+} /* detail */
+
+template<class A, class T, class = void>
+struct allocator_rebind {
+    typedef typename detail::alloc_to<A, T>::type type;
+};
+
+template<class A, class T>
+struct allocator_rebind<A, T,
+    typename detail::alloc_void<typename A::template rebind<T>::other>::type> {
+    typedef typename A::template rebind<T>::other type;
+};
+
+template<class A>
+inline typename allocator_pointer<A>::type
+allocator_allocate(A& a, typename allocator_size_type<A>::type n)
+{
+    return a.allocate(n);
+}
+
+namespace detail {
+
+template<bool, class = void>
+struct alloc_if { };
+
+template<class R>
+struct alloc_if<true, R> {
+    typedef R type;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+template<class T>
+T alloc_declval() BOOST_NOEXCEPT;
+#endif
+
+template<class, class = void>
+struct alloc_has_allocate {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+template<class A>
+struct alloc_has_allocate<A, typename
+    alloc_void<decltype(alloc_declval<A&>().allocate(alloc_declval<typename
+        boost::allocator_size_type<A>::type>(), alloc_declval<typename
+            boost::allocator_const_void_pointer<A>::type>()))>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#endif
+
+} /* detail */
+
+template<class A>
+inline typename detail::alloc_if<detail::alloc_has_allocate<A>::value,
+    typename allocator_pointer<A>::type>::type
+allocator_allocate(A& a, typename allocator_size_type<A>::type n,
+    typename allocator_const_void_pointer<A>::type h)
+{
+    return a.allocate(n, h);
+}
+
+template<class A>
+inline typename detail::alloc_if<!detail::alloc_has_allocate<A>::value,
+    typename allocator_pointer<A>::type>::type
+allocator_allocate(A& a, typename allocator_size_type<A>::type n,
+    typename allocator_const_void_pointer<A>::type)
+{
+    return a.allocate(n);
+}
+
+template<class A>
+inline void
+allocator_deallocate(A& a, typename allocator_pointer<A>::type p,
+    typename allocator_size_type<A>::type n)
+{
+    a.deallocate(p, n);
+}
+
+namespace detail {
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<class...>
+struct alloc_types { };
+#else
+template<class>
+struct alloc_types { };
+#endif
+
+template<class, class, class, class = void>
+struct alloc_has_construct {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<class A, class T, class... U>
+struct alloc_has_construct<A, T, alloc_types<U...>, typename
+    alloc_void<decltype(alloc_declval<A&>().construct(alloc_declval<T*>(),
+        alloc_declval<U>()...))>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#else
+template<class A, class T, class U>
+struct alloc_has_construct<A, T, alloc_types<U>, typename
+    alloc_void<decltype(alloc_declval<A&>().construct(alloc_declval<T*>(),
+        alloc_declval<U>()))>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#endif
+#endif
+
+} /* detail */
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<class A, class T, class... Args>
+inline typename detail::alloc_if<detail::alloc_has_construct<A, T,
+    detail::alloc_types<Args...> >::value>::type
+allocator_construct(A& a, T*p, Args&&... args)
+{
+    a.construct(p, std::forward<Args>(args)...);
+}
+
+template<class A, class T, class... Args>
+inline typename detail::alloc_if<!detail::alloc_has_construct<A, T,
+    detail::alloc_types<Args...> >::value>::type
+allocator_construct(A&, T* p, Args&&... args)
+{
+    ::new(static_cast<void*>(p)) T(std::forward<Args>(args)...);
+}
+#else
+template<class A, class T, class V>
+inline typename detail::alloc_if<detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A& a, T*p, V&& v)
+{
+    a.construct(p, std::forward<V>(v));
+}
+
+template<class A, class T, class V>
+inline typename detail::alloc_if<!detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A&, T* p, V&& v)
+{
+    ::new(static_cast<void*>(p)) T(std::forward<V>(v));
+}
+#endif
+#else
+template<class A, class T, class V>
+inline typename detail::alloc_if<detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A& a, T*p, const V& v)
+{
+    a.construct(p, v);
+}
+
+template<class A, class T, class V>
+inline typename detail::alloc_if<!detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A&, T* p, const V& v)
+{
+    ::new(static_cast<void*>(p)) T(v);
+}
+
+template<class A, class T, class V>
+inline typename detail::alloc_if<detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A& a, T*p, V& v)
+{
+    a.construct(p, v);
+}
+
+template<class A, class T, class V>
+inline typename detail::alloc_if<!detail::alloc_has_construct<A, T,
+    detail::alloc_types<V> >::value>::type
+allocator_construct(A&, T* p, V& v)
+{
+    ::new(static_cast<void*>(p)) T(v);
+}
+#endif
+
+namespace detail {
+
+template<class, class, class = void>
+struct alloc_has_destroy {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+template<class A, class T>
+struct alloc_has_destroy<A, T, typename
+    alloc_void<decltype(alloc_declval<A&>().
+        destroy(alloc_declval<T*>()))>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#endif
+
+} /* detail */
+
+template<class A, class T>
+inline typename detail::alloc_if<detail::alloc_has_destroy<A, T>::value>::type
+allocator_destroy(A& a, T*p)
+{
+    a.destroy(p);
+}
+
+template<class A, class T>
+inline typename detail::alloc_if<!detail::alloc_has_destroy<A, T>::value>::type
+allocator_destroy(A&, T* p)
+{
+    p->~T();
+    (void)p;
+}
+
+namespace detail {
+
+template<class, class = void>
+struct alloc_has_max_size {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+template<class A>
+struct alloc_has_max_size<A,
+    typename alloc_void<decltype(alloc_declval<const
+        A&>().max_size())>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#endif
+
+} /* detail */
+
+template<class A>
+inline typename detail::alloc_if<detail::alloc_has_max_size<A>::value,
+    typename allocator_size_type<A>::type>::type
+allocator_max_size(const A& a)
+{
+    return a.max_size();
+}
+
+template<class A>
+inline typename detail::alloc_if<!detail::alloc_has_max_size<A>::value,
+    typename allocator_size_type<A>::type>::type
+allocator_max_size(const A&)
+{
+    return std::numeric_limits<typename allocator_size_type<A>::type>::max() /
+        sizeof(typename A::value_type);
+}
+
+namespace detail {
+
+template<class, class = void>
+struct alloc_has_soccc {
+    BOOST_STATIC_CONSTEXPR bool value = false;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+template<class A>
+struct alloc_has_soccc<A,
+    typename alloc_void<decltype(alloc_declval<const
+        A&>().select_on_container_copy_construction())>::type> {
+    BOOST_STATIC_CONSTEXPR bool value = true;
+};
+#endif
+
+} /* detail */
+
+template<class A>
+inline typename detail::alloc_if<detail::alloc_has_soccc<A>::value, A>::type
+allocator_select_on_container_copy_construction(const A& a)
+{
+    return a.select_on_container_copy_construction();
+}
+
+template<class A>
+inline typename detail::alloc_if<!detail::alloc_has_soccc<A>::value, A>::type
+allocator_select_on_container_copy_construction(const A& a)
+{
+    return a;
+}
+
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+template<class A>
+using allocator_value_type_t = typename allocator_value_type<A>::type;
+
+template<class A>
+using allocator_pointer_t = typename allocator_pointer<A>::type;
+
+template<class A>
+using allocator_const_pointer_t = typename allocator_const_pointer<A>::type;
+
+template<class A>
+using allocator_void_pointer_t = typename allocator_void_pointer<A>::type;
+
+template<class A>
+using allocator_const_void_pointer_t =
+    typename allocator_const_void_pointer<A>::type;
+
+template<class A>
+using allocator_difference_type_t =
+    typename allocator_difference_type<A>::type;
+
+template<class A>
+using allocator_size_type_t = typename allocator_size_type<A>::type;
+
+template<class A>
+using allocator_propagate_on_container_copy_assignment_t =
+    typename allocator_propagate_on_container_copy_assignment<A>::type;
+
+template<class A>
+using allocator_propagate_on_container_move_assignment_t =
+    typename allocator_propagate_on_container_move_assignment<A>::type;
+
+template<class A>
+using allocator_propagate_on_container_swap_t =
+    typename allocator_propagate_on_container_swap<A>::type;
+
+template<class A>
+using allocator_is_always_equal_t =
+    typename allocator_is_always_equal<A>::type;
+
+template<class A, class T>
+using allocator_rebind_t = typename allocator_rebind<A, T>::type;
+#endif
+
+} /* boost */
+
+#endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -161,6 +161,24 @@ run alloc_construct_cxx11_test.cpp ;
 
 run nvp_test.cpp ;
 
+run allocator_value_type_test.cpp ;
+run allocator_pointer_test.cpp ;
+run allocator_const_pointer_test.cpp ;
+run allocator_void_pointer_test.cpp ;
+run allocator_const_void_pointer_test.cpp ;
+run allocator_difference_type_test.cpp ;
+run allocator_size_type_test.cpp ;
+run allocator_pocca_test.cpp ;
+run allocator_pocma_test.cpp ;
+run allocator_pocs_test.cpp ;
+run allocator_is_always_equal_test.cpp ;
+run allocator_rebind_test.cpp ;
+run allocator_allocate_test.cpp ;
+run allocator_allocate_hint_test.cpp ;
+run allocator_deallocate_test.cpp ;
+run allocator_max_size_test.cpp ;
+run allocator_soccc_test.cpp ;
+
 lib lib_typeid : lib_typeid.cpp : <link>shared:<define>LIB_TYPEID_DYN_LINK=1 ;
 
 run test_lib_typeid.cpp lib_typeid : : : <link>shared : test_lib_typeid_shared ;

--- a/test/allocator_allocate_hint_test.cpp
+++ b/test/allocator_allocate_hint_test.cpp
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct A1 {
+    typedef int* pointer;
+    typedef int size_type;
+
+    A1()
+        : value() { }
+
+    pointer allocate(size_type n) {
+        value = n;
+        return &value;
+    }
+
+    size_type value;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+struct A2 {
+    typedef int* pointer;
+    typedef int size_type;
+
+    A2()
+        : value() { }
+
+    pointer allocate(size_type n) {
+        value = n;
+        return &value;
+    }
+
+    pointer allocate(size_type n, const void*) {
+        value = n + 1;
+        return &value;
+    }
+
+    size_type value;
+};
+#endif
+
+int main()
+{
+    {
+        A1 a;
+        BOOST_TEST_EQ(*boost::allocator_allocate(a, 1, 0), 1);
+    }
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+    {
+        A2 a;
+        BOOST_TEST_EQ(*boost::allocator_allocate(a, 1, 0), 2);
+    }
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_allocate_test.cpp
+++ b/test/allocator_allocate_test.cpp
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct A {
+    typedef int* pointer;
+    typedef int size_type;
+
+    A()
+        : value() { }
+
+    pointer allocate(size_type n) {
+        value = n;
+        return &value;
+    }
+
+    size_type value;
+};
+
+int main()
+{
+    A a;
+    BOOST_TEST_EQ(*boost::allocator_allocate(a, 5), 5);
+    return boost::report_errors();
+}

--- a/test/allocator_const_pointer_test.cpp
+++ b/test/allocator_const_pointer_test.cpp
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    typedef char value_type;
+    typedef int* pointer;
+};
+
+struct A2 {
+    typedef char value_type;
+    typedef int* pointer;
+    typedef const bool* const_pointer;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const char*,
+        boost::allocator_const_pointer<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const bool*,
+        boost::allocator_const_pointer<A2>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_const_void_pointer_test.cpp
+++ b/test/allocator_const_void_pointer_test.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    typedef int* pointer;
+};
+
+struct A2 {
+    typedef int* pointer;
+    typedef const bool* const_void_pointer;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const void*,
+        boost::allocator_const_void_pointer<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const bool*,
+        boost::allocator_const_void_pointer<A2>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_construct_test.cpp
+++ b/test/allocator_construct_test.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/default_allocator.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct S {
+    S(int v)
+        : value(v) { }
+
+    int value;
+};
+
+struct A1 { };
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+struct A2 {
+    void construct(S* p, int v) {
+        new(p) S(v + 1);
+    }
+};
+#endif
+
+int main()
+{
+    boost::default_allocator<S> d;
+    {
+        S* p = d.allocate(1);
+        A1 a;
+        boost::allocator_construct(a, p, 1);
+        BOOST_TEST_EQ(p->value, 1);
+        d.deallocate(p, 1);
+    }
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+    {
+        S* p = d.allocate(1);
+        A2 a;
+        boost::allocator_construct(a, p, 1);
+        BOOST_TEST_EQ(p->value, 2);
+        d.deallocate(p, 1);
+    }
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_deallocate_test.cpp
+++ b/test/allocator_deallocate_test.cpp
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct A {
+    typedef int* pointer;
+    typedef int size_type;
+
+    A()
+        : value() { }
+
+    void deallocate(pointer, size_type n) {
+        value = n;
+    }
+
+    size_type value;
+};
+
+int main()
+{
+    A a;
+    boost::allocator_deallocate(a, 0, 5);
+    BOOST_TEST_EQ(a.value, 5);
+    return boost::report_errors();
+}

--- a/test/allocator_destroy_test.cpp
+++ b/test/allocator_destroy_test.cpp
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/default_allocator.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct S {
+    static int count;
+
+    S() {
+        ++count;
+    }
+
+    S(const S&) {
+        ++count;
+    }
+
+    ~S() {
+        --count;
+    }
+};
+
+int S::count = 0;
+
+struct A1 { };
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+struct A2 {
+    void destroy(S*) {
+        ++S::count;
+    }
+};
+#endif
+
+int main()
+{
+    boost::default_allocator<S> d;
+    {
+        S* p = d.allocate(1);
+        new(p) S;
+        A1 a;
+        boost::allocator_destroy(a, p);
+        BOOST_TEST_EQ(S::count, 0);
+        d.deallocate(p, 1);
+    }
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+    {
+        S* p = d.allocate(1);
+        new(p) S;
+        A2 a;
+        boost::allocator_destroy(a, p);
+        BOOST_TEST_EQ(S::count, 2);
+        d.deallocate(p, 1);
+    }
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_difference_type_test.cpp
+++ b/test/allocator_difference_type_test.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    typedef char* pointer;
+};
+
+struct A2 {
+    typedef char* pointer;
+    typedef int difference_type;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+        boost::allocator_difference_type<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+        boost::allocator_difference_type<A2>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_is_always_equal_test.cpp
+++ b/test/allocator_is_always_equal_test.cpp
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    int value;
+};
+
+struct A2 {
+    struct is_always_equal {
+        BOOST_STATIC_CONSTEXPR bool value = true;
+    };
+
+    int value;
+};
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+struct A3 { };
+#endif
+
+int main()
+{
+    BOOST_TEST_TRAIT_FALSE((boost::allocator_is_always_equal<A1>::type));
+    BOOST_TEST_TRAIT_TRUE((boost::allocator_is_always_equal<A2>::type));
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+    BOOST_TEST_TRAIT_TRUE((boost::allocator_is_always_equal<A3>::type));
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_max_size_test.cpp
+++ b/test/allocator_max_size_test.cpp
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct A1 {
+    typedef long value_type;
+    typedef short size_type;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+struct A2 {
+    typedef long value_type;
+    typedef short size_type;
+
+    size_type max_size() const {
+        return 1;
+    }
+};
+#endif
+
+int main()
+{
+    BOOST_TEST_EQ(boost::allocator_max_size(A1()),
+        std::numeric_limits<A1::size_type>::max() / sizeof(A1::value_type));
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+    BOOST_TEST_EQ(boost::allocator_max_size(A2()), 1);
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_pocca_test.cpp
+++ b/test/allocator_pocca_test.cpp
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 { };
+
+struct A2 {
+    struct propagate_on_container_copy_assignment {
+        BOOST_STATIC_CONSTEXPR bool value = true;
+    };
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_FALSE((boost::
+        allocator_propagate_on_container_copy_assignment<A1>::type));
+    BOOST_TEST_TRAIT_TRUE((boost::
+        allocator_propagate_on_container_copy_assignment<A2>::type));
+    return boost::report_errors();
+}

--- a/test/allocator_pocma_test.cpp
+++ b/test/allocator_pocma_test.cpp
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 { };
+
+struct A2 {
+    struct propagate_on_container_move_assignment {
+        BOOST_STATIC_CONSTEXPR bool value = true;
+    };
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_FALSE((boost::
+        allocator_propagate_on_container_move_assignment<A1>::type));
+    BOOST_TEST_TRAIT_TRUE((boost::
+        allocator_propagate_on_container_move_assignment<A2>::type));
+    return boost::report_errors();
+}

--- a/test/allocator_pocs_test.cpp
+++ b/test/allocator_pocs_test.cpp
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 { };
+
+struct A2 {
+    struct propagate_on_container_swap {
+        BOOST_STATIC_CONSTEXPR bool value = true;
+    };
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_FALSE((boost::
+        allocator_propagate_on_container_swap<A1>::type));
+    BOOST_TEST_TRAIT_TRUE((boost::
+        allocator_propagate_on_container_swap<A2>::type));
+    return boost::report_errors();
+}

--- a/test/allocator_pointer_test.cpp
+++ b/test/allocator_pointer_test.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    typedef char value_type;
+};
+
+struct A2 {
+    typedef char value_type;
+    typedef int* pointer;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<char*,
+        boost::allocator_pointer<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+        boost::allocator_pointer<A2>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_rebind_test.cpp
+++ b/test/allocator_rebind_test.cpp
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+template<class, class, class>
+struct A1 { };
+
+template<class, class U, class V>
+struct A2 {
+    template<class T>
+    struct rebind {
+        typedef A1<T, U, V> other;
+    };
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<A1<bool, int, float>,
+        boost::allocator_rebind<A1<char, int, float>, bool>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<A1<bool, int, float>,
+        boost::allocator_rebind<A2<char, int, float>, bool>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_size_type_test.cpp
+++ b/test/allocator_size_type_test.cpp
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+struct A1 {
+    typedef long difference_type;
+};
+#else
+struct A1 {
+    typedef unsigned long size_type;
+};
+#endif
+
+struct A2 {
+    typedef long difference_type;
+    typedef unsigned short size_type;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<unsigned long,
+        boost::allocator_size_type<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<unsigned short,
+        boost::allocator_size_type<A2>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_soccc_test.cpp
+++ b/test/allocator_soccc_test.cpp
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+struct A1 {
+    A1(int v)
+        : value(v) { }
+
+    int value;
+};
+
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+struct A2 {
+    A2(int v)
+        : value(v) { }
+
+    A2 select_on_container_copy_construction() const {
+        return A2(value + 1);
+    }
+
+    int value;
+};
+#endif
+
+int main()
+{
+    BOOST_TEST_EQ(1,
+        boost::allocator_select_on_container_copy_construction(A1(1)).value);
+#if defined(BOOST_CORE_ALLOCATOR_DETECTION)
+    BOOST_TEST_EQ(2,
+        boost::allocator_select_on_container_copy_construction(A2(1)).value);
+#endif
+    return boost::report_errors();
+}

--- a/test/allocator_value_type_test.cpp
+++ b/test/allocator_value_type_test.cpp
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A {
+    typedef int value_type;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+        boost::allocator_value_type<A>::type>));
+    return boost::report_errors();
+}

--- a/test/allocator_void_pointer_test.cpp
+++ b/test/allocator_void_pointer_test.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/allocator_access.hpp>
+#include <boost/core/is_same.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+struct A1 {
+    typedef int* pointer;
+};
+
+struct A2 {
+    typedef int* pointer;
+    typedef bool* void_pointer;
+};
+
+int main()
+{
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void*,
+        boost::allocator_void_pointer<A1>::type>));
+    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool*,
+        boost::allocator_void_pointer<A2>::type>));
+    return boost::report_errors();
+}


### PR DESCRIPTION
Instead of `allocator_traits` in Core, the same functionality provided by individual templates. This reflects recent C++ standard committee reflector discussion around how `allocator_traits` would be designed today instead.