### PR TITLE
Small GHA fix, create destination dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
           cd ..
           git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
+          mkdir -p libs/$LIBRARY
           cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
           git submodule update --init tools/boostdep
           python tools/boostdep/depinst/depinst.py --git_args "--jobs $GIT_FETCH_JOBS" $LIBRARY


### PR DESCRIPTION
Earlier, I copied ci.yml from boostorg/core to boostorg/boost-ci where it can be used as a template when setting up new boost libraries.  Discovered a problem - if a new library doesn't yet exist in boost, the lib directory won't exist, and a copy will fail.   So, create the directory first.  It would be convenient to backport the change upstream, here.  Or even to any repo that might later be used as an example.