### PR TITLE
bit.hpp: Fix MSVC warnings about constant conditional expressions

### DIFF
--- a/include/boost/core/bit.hpp
+++ b/include/boost/core/bit.hpp
@@ -31,6 +31,12 @@
 # endif
 #endif // defined(_MSC_VER)
 
+#if defined(BOOST_MSVC)
+# pragma warning(push, 3)
+// conditional expression is constant
+# pragma warning(disable: 4127)
+#endif // defined(BOOST_MSVC)
+
 namespace boost
 {
 namespace core
@@ -577,5 +583,9 @@ typedef endian::type endian_type;
 
 } // namespace core
 } // namespace boost
+
+#if defined(BOOST_MSVC)
+# pragma warning(pop)
+#endif // defined(BOOST_MSVC)
 
 #endif  // #ifndef BOOST_CORE_BIT_HPP_INCLUDED

--- a/include/boost/core/bit.hpp
+++ b/include/boost/core/bit.hpp
@@ -164,15 +164,15 @@ int countl_zero( T x ) BOOST_NOEXCEPT
 {
     BOOST_STATIC_ASSERT( sizeof(T) == sizeof(boost::uint8_t) || sizeof(T) == sizeof(boost::uint16_t) || sizeof(T) == sizeof(boost::uint32_t) || sizeof(T) == sizeof(boost::uint64_t) );
 
-    if( sizeof(T) == sizeof(boost::uint8_t) )
+    BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint8_t) )
     {
         return boost::core::detail::countl_impl( static_cast<boost::uint8_t>( x ) );
     }
-    else if( sizeof(T) == sizeof(boost::uint16_t) )
+    else BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint16_t) )
     {
         return boost::core::detail::countl_impl( static_cast<boost::uint16_t>( x ) );
     }
-    else if( sizeof(T) == sizeof(boost::uint32_t) )
+    else BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint32_t) )
     {
         return boost::core::detail::countl_impl( static_cast<boost::uint32_t>( x ) );
     }
@@ -299,15 +299,15 @@ int countr_zero( T x ) BOOST_NOEXCEPT
 {
     BOOST_STATIC_ASSERT( sizeof(T) == sizeof(boost::uint8_t) || sizeof(T) == sizeof(boost::uint16_t) || sizeof(T) == sizeof(boost::uint32_t) || sizeof(T) == sizeof(boost::uint64_t) );
 
-    if( sizeof(T) == sizeof(boost::uint8_t) )
+    BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint8_t) )
     {
         return boost::core::detail::countr_impl( static_cast<boost::uint8_t>( x ) );
     }
-    else if( sizeof(T) == sizeof(boost::uint16_t) )
+    else BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint16_t) )
     {
         return boost::core::detail::countr_impl( static_cast<boost::uint16_t>( x ) );
     }
-    else if( sizeof(T) == sizeof(boost::uint32_t) )
+    else BOOST_IF_CONSTEXPR ( sizeof(T) == sizeof(boost::uint32_t) )
     {
         return boost::core::detail::countr_impl( static_cast<boost::uint32_t>( x ) );
     }
@@ -403,7 +403,7 @@ BOOST_CXX14_CONSTEXPR int popcount( T x ) BOOST_NOEXCEPT
 {
     BOOST_STATIC_ASSERT( sizeof(T) <= sizeof(boost::uint64_t) );
 
-    if( sizeof(T) <= sizeof(boost::uint32_t) )
+    BOOST_IF_CONSTEXPR ( sizeof(T) <= sizeof(boost::uint32_t) )
     {
         return boost::core::detail::popcount_impl( static_cast<boost::uint32_t>( x ) );
     }
@@ -502,7 +502,7 @@ BOOST_CXX14_CONSTEXPR T bit_ceil( T x ) BOOST_NOEXCEPT
 {
     BOOST_STATIC_ASSERT( sizeof(T) <= sizeof(boost::uint64_t) );
 
-    if( sizeof(T) <= sizeof(boost::uint32_t) )
+    BOOST_IF_CONSTEXPR ( sizeof(T) <= sizeof(boost::uint32_t) )
     {
         return static_cast<T>( boost::core::detail::bit_ceil_impl( static_cast<boost::uint32_t>( x ) ) );
     }


### PR DESCRIPTION
Also use `if constexpr` where possible.

Closes https://github.com/boostorg/core/issues/98.