### PR TITLE
Add value member to allocator_is_always_equal

### DIFF
--- a/include/boost/core/allocator_access.hpp
+++ b/include/boost/core/allocator_access.hpp
@@ -236,12 +236,14 @@ struct allocator_is_always_equal {
 template<class A, class = void>
 struct allocator_is_always_equal {
     typedef typename std::is_empty<A>::type type;
+    BOOST_STATIC_CONSTEXPR type value;
 };
 
 template<class A>
 struct allocator_is_always_equal<A,
     typename detail::alloc_void<typename A::is_always_equal>::type> {
     typedef typename A::is_always_equal type;
+    BOOST_STATIC_CONSTEXPR type value;
 };
 #endif
 


### PR DESCRIPTION
In order to use `boost::allocator_is_always_equal` with e.g.
`boost::unordered_set` a `value` member is required to exist in the
struct, else a compilation error is encountered:

```
C:\usr\local\include\boost-1_77\boost/unordered/unordered_set.hpp(170,1): error C2039: 'value': is not a member of 'boost::allocator_is_always_equal<Alloc,void>'
        with
        [
            Alloc=std::allocator<std::string>
        ]
        BOOST_NOEXCEPT_IF(value_allocator_traits::is_always_equal::value&&
```

Encountered with boost version 1.77, on OS Windows Server 2016 with
compiler version MSVC 19.29.30136 for x64