### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
 
           - toolset: clang
             cxxstd: "03,11,14,17,2a"
-            os: macos-10.15
+            os: macos-11
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
@@ -532,7 +532,7 @@ jobs:
           - os: ubuntu-18.04
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-10.15
+          - os: macos-11
 
     runs-on: ${{matrix.os}}
 
@@ -579,7 +579,7 @@ jobs:
           - os: ubuntu-18.04
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-10.15
+          - os: macos-11
 
     runs-on: ${{matrix.os}}
 
@@ -636,7 +636,7 @@ jobs:
           - os: ubuntu-18.04
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-10.15
+          - os: macos-11
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22