### PR TITLE
Fix typos in docs

### DIFF
--- a/doc/allocator_access.qbk
+++ b/doc/allocator_access.qbk
@@ -293,7 +293,7 @@ returns `a`.]]]
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 Glen Fernandes implemented the allocator access utilities.
 

--- a/doc/checked_delete.qbk
+++ b/doc/checked_delete.qbk
@@ -124,7 +124,7 @@ template<class T> struct checked_array_deleter
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 The function templates `checked_delete` and
 `checked_array_delete` were originally part of

--- a/doc/checked_delete.qbk
+++ b/doc/checked_delete.qbk
@@ -124,7 +124,7 @@ template<class T> struct checked_array_deleter
 
 [endsect]
 
-[section Acknowledgements]
+[section Acknowledgments]
 
 The function templates `checked_delete` and
 `checked_array_delete` were originally part of

--- a/doc/demangle.qbk
+++ b/doc/demangle.qbk
@@ -125,7 +125,7 @@ return `nullptr` if demangling failed.
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 The implementation of `core::demangle` was taken from
 `boost/exception/detail/type_info.hpp`, which in turn was adapted

--- a/doc/enable_if.qbk
+++ b/doc/enable_if.qbk
@@ -473,7 +473,7 @@ Two workarounds can be applied:
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 We are grateful to Howard Hinnant, Jason Shirk, Paul
 Mensonides, and Richard Smith whose findings have

--- a/doc/enable_if.qbk
+++ b/doc/enable_if.qbk
@@ -304,8 +304,8 @@ depends on the template arguments of the class. Note that
 again, the second argument to `enable_if` is not needed; the
 default (`void`) is the correct value.
 
-The `enable_if_has_type` template is usable this scenario but instead of
-using a type traits to enable or disable a specialization, it use a
+The `enable_if_has_type` template is usable in this scenario but instead of
+using a type trait to enable or disable a specialization, it uses a
 SFINAE context to check for the existence of a dependent type inside
 its parameter. For example, the following structure extracts a dependent
 `value_type` from T if and only if `T::value_type` exists.
@@ -473,7 +473,7 @@ Two workarounds can be applied:
 
 [endsect]
 
-[section Acknowledgements]
+[section Acknowledgments]
 
 We are grateful to Howard Hinnant, Jason Shirk, Paul
 Mensonides, and Richard Smith whose findings have

--- a/doc/ignore_unused.qbk
+++ b/doc/ignore_unused.qbk
@@ -51,7 +51,7 @@ int fun( int foo, int bar )
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 `boost::ignore_unused()` was contributed by Adam Wulkiewicz.
 

--- a/doc/pointer_traits.qbk
+++ b/doc/pointer_traits.qbk
@@ -165,7 +165,7 @@ also not defined (`pointer_traits` is SFINAE-friendly).
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 Glen Fernandes implemented `pointer_traits` and `to_address` with reviews and
 guidance from Peter Dimov.

--- a/doc/pointer_traits.qbk
+++ b/doc/pointer_traits.qbk
@@ -124,7 +124,7 @@ also not defined (`pointer_traits` is SFINAE-friendly).
 [[`static pointer pointer_traits::pointer_to(element_type& v);`]
 [[variablelist
 [[Remark]
-[If `element_type` is a void type, or if `T::pointer_to(v)` is not well formed,
+[If `element_type` is a void type, or if `T::pointer_to(v)` is not well-formed,
   this member is not defined.]]
 [[Returns]
 [A pointer to `v` obtained by calling `T::pointer_to(v)`.]]]]]

--- a/doc/ref.qbk
+++ b/doc/ref.qbk
@@ -68,7 +68,7 @@ The type-expression `boost::unwrap_reference<T>::type` is
 
 [xinclude ref_reference.xml]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 `ref` and `cref` were originally part of the Tuple library by
 Jaakko J\u00E4rvi. They were "promoted to `boost::` status" by

--- a/doc/scoped_enum.qbk
+++ b/doc/scoped_enum.qbk
@@ -179,7 +179,7 @@ such cases.
 
 [endsect]
 
-[section Acknowledgments]
+[section Acknowledgements]
 
 This scoped enum emulation was developed by Beman Dawes, Vicente J. Botet Escriba and Anthony Williams.
 

--- a/doc/scoped_enum.qbk
+++ b/doc/scoped_enum.qbk
@@ -46,7 +46,7 @@ The user can portably declare such enumeration as follows:
     }
     BOOST_SCOPED_ENUM_DECLARE_END(future_errc)
 
-These macros allows to use `future_errc` in almost all the cases as an scoped enum.
+These macros allow using `future_errc` in almost all the cases as a scoped enum.
 
     future_errc ev = future_errc::no_state;
 

--- a/doc/use_default.qbk
+++ b/doc/use_default.qbk
@@ -11,7 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 [section Overview]
 
 The header <boost/core/use_default.hpp> provides the type `boost::use_default`
-which is used by other Boost libraries as a sentinel type in a templates to
+which is used by other Boost libraries as a sentinel type in templates to
 indicate defaults.
 
 [endsect]


### PR DESCRIPTION
Use "Acknowledgments" everywhere for consistency.