### PR TITLE
Add fclose_deleter

### DIFF
--- a/doc/core.qbk
+++ b/doc/core.qbk
@@ -60,6 +60,7 @@ criteria for inclusion is that the utility component be:
 [include noinit_adaptor.qbk]
 [include noncopyable.qbk]
 [include null_deleter.qbk]
+[include fclose_deleter.qbk]
 [include nvp.qbk]
 [include pointer_traits.qbk]
 [include quick_exit.qbk]

--- a/doc/fclose_deleter.qbk
+++ b/doc/fclose_deleter.qbk
@@ -1,0 +1,34 @@
+[/
+ / Copyright (c) 2022 Andrey Semashev
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+[section:fclose_deleter fclose_deleter]
+
+[simplesect Authors]
+
+* Andrey Semashev
+
+[endsimplesect]
+
+[section Header <boost/core/fclose_deleter.hpp>]
+
+The header `<boost/core/fclose_deleter.hpp>` defines the `boost::fclose_deleter` function object,
+which can be used as a deleter with smart pointers such as `unique_ptr` or `shared_ptr` pointing to `std::FILE`.
+structures returned by `std::fopen` calls. The deleter calls `std::fclose` on the passed pointer, causing
+the file stream to be flushed and closed.
+
+[section Example]
+``
+std::unique_ptr< std::FILE, boost::fclose_deleter > make_file(const char* filename, const char* open_mode)
+{
+    return { std::fopen(filename, open_mode) };
+}
+``
+[endsect]
+
+[endsect]
+
+[endsect]

--- a/include/boost/core/fclose_deleter.hpp
+++ b/include/boost/core/fclose_deleter.hpp
@@ -1,0 +1,45 @@
+/*
+ *             Copyright Andrey Semashev 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   fclose_deleter.hpp
+ * \author Andrey Semashev
+ * \date   21.09.2022
+ *
+ * This header contains an \c fclose_deleter implementation. This is a deleter
+ * function object that invokes <tt>std::fclose</tt> on the passed pointer to
+ * a <tt>std::FILE</tt> structure.
+ */
+
+#ifndef BOOST_CORE_FCLOSE_DELETER_HPP
+#define BOOST_CORE_FCLOSE_DELETER_HPP
+
+#include <cstdio>
+#include <boost/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+//! A function object that closes a file
+struct fclose_deleter
+{
+    //! Function object result type
+    typedef void result_type;
+    /*!
+     * Closes the file handle
+     */
+    void operator() (std::FILE* p) const BOOST_NOEXCEPT
+    {
+        std::fclose(p);
+    }
+};
+
+} // namespace boost
+
+#endif // BOOST_CORE_FCLOSE_DELETER_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -186,6 +186,9 @@ compile-fail scoped_enum_compile_fail_conv_to_int.cpp
 
 run underlying_type.cpp ;
 
+compile fclose_deleter_test.cpp
+  : <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS <target-os>windows:<define>_CRT_SECURE_NO_DEPRECATE ;
+
 run pointer_traits_pointer_test.cpp ;
 run pointer_traits_element_type_test.cpp ;
 run pointer_traits_difference_type_test.cpp ;

--- a/test/fclose_deleter_test.cpp
+++ b/test/fclose_deleter_test.cpp
@@ -1,0 +1,52 @@
+/*
+ *             Copyright Andrey Semashev 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   fclose_deleter_test.cpp
+ * \author Andrey Semashev
+ * \date   21.09.2022
+ *
+ * This file contains tests for \c boost::fclose_deleter.
+ */
+
+#include <boost/core/fclose_deleter.hpp>
+#include <cstdio>
+#include <cstddef>
+#include <boost/config.hpp>
+#if !defined(BOOST_NO_CXX11_SMART_PTR)
+#include <memory>
+#endif
+
+#if !defined(BOOST_NO_CXX11_SMART_PTR)
+std::unique_ptr< std::FILE, boost::fclose_deleter > make_unique_file(const char* filename)
+{
+    return std::unique_ptr< std::FILE, boost::fclose_deleter >(std::fopen(filename, "w"));
+}
+
+std::shared_ptr< std::FILE > make_shared_file(const char* filename)
+{
+    return std::shared_ptr< std::FILE >(std::fopen(filename, "w"), boost::fclose_deleter());
+}
+#endif
+
+int main()
+{
+    const char* const filename = "fcd_test.txt";
+
+    std::FILE* file = std::fopen(filename, "w");
+    if (file)
+    {
+        boost::fclose_deleter()(file);
+        file = NULL;
+    }
+
+#if !defined(BOOST_NO_CXX11_SMART_PTR)
+    make_unique_file(filename);
+    make_shared_file(filename);
+#endif
+
+    std::remove(filename);
+}

--- a/test/quick.cpp
+++ b/test/quick.cpp
@@ -20,6 +20,7 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/core/null_deleter.hpp>
+#include <boost/core/fclose_deleter.hpp>
 #include <boost/core/pointer_traits.hpp>
 #include <boost/ref.hpp>
 #include <boost/core/scoped_enum.hpp>


### PR DESCRIPTION
`fclose_deleter` can be used as a deleter function object for `std::FILE` pointers returned by `std::fopen`.