### PR TITLE
Fix for sprintf deprecation warning

### DIFF
--- a/include/boost/core/lightweight_test.hpp
+++ b/include/boost/core/lightweight_test.hpp
@@ -202,6 +202,14 @@ inline unsigned long test_output_impl( char32_t const& v ) { return v; }
 #pragma warning(disable: 4996)
 #endif
 
+// Use snprintf if available as some complilers (clang 14.0) issue deprecation warnings for sprintf
+#if ( defined(_MSC_VER) && _MSC_VER < 1900 ) || ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) ) || \
+    ( defined(__cplusplus) && __cplusplus < 201103L)
+# define BOOST_CORE_SNPRINTF(buffer, format, arg) std::sprintf(buffer, format, arg)
+#else
+# define BOOST_CORE_SNPRINTF(buffer, format, arg) std::snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), format, arg)
+#endif
+
 inline std::string test_output_impl( char const& v )
 {
     if( std::isprint( static_cast<unsigned char>( v ) ) )
@@ -211,7 +219,7 @@ inline std::string test_output_impl( char const& v )
     else
     {
         char buffer[ 8 ];
-        std::sprintf( buffer, "\\x%02X", static_cast<unsigned char>( v ) );
+        BOOST_CORE_SNPRINTF( buffer, "\\x%02X", static_cast<unsigned char>( v ) );
 
         return buffer;
     }

--- a/include/boost/core/lightweight_test.hpp
+++ b/include/boost/core/lightweight_test.hpp
@@ -202,9 +202,8 @@ inline unsigned long test_output_impl( char32_t const& v ) { return v; }
 #pragma warning(disable: 4996)
 #endif
 
-// Use snprintf if available as some complilers (clang 14.0) issue deprecation warnings for sprintf
-#if ( defined(_MSC_VER) && _MSC_VER < 1900 ) || ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) ) || \
-    ( defined(__cplusplus) && __cplusplus < 201103L)
+// Use snprintf if available as some compilers (clang 14.0) issue deprecation warnings for sprintf
+#if ( defined(_MSC_VER) && _MSC_VER < 1900 ) || ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) )
 # define BOOST_CORE_SNPRINTF(buffer, format, arg) std::sprintf(buffer, format, arg)
 #else
 # define BOOST_CORE_SNPRINTF(buffer, format, arg) std::snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), format, arg)
@@ -224,6 +223,8 @@ inline std::string test_output_impl( char const& v )
         return buffer;
     }
 }
+
+#undef BOOST_CORE_SNPRINTF
 
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/include/boost/core/type_name.hpp
+++ b/include/boost/core/type_name.hpp
@@ -185,13 +185,22 @@ template<class T> std::string array_template_name()
 # pragma warning( disable: 4996 )
 #endif
 
+// Use snprintf if available as some compilers (clang 14.0) issue deprecation warnings for sprintf
+#if ( defined(_MSC_VER) && _MSC_VER < 1900 ) || ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) )
+# define BOOST_CORE_SNPRINTF(buffer, format, arg) std::sprintf(buffer, format, arg)
+#else
+# define BOOST_CORE_SNPRINTF(buffer, format, arg) std::snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), format, arg)
+#endif
+
 inline std::string tn_to_string( std::size_t n )
 {
     char buffer[ 32 ];
-    std::sprintf( buffer, "%lu", static_cast< unsigned long >( n ) );
+    BOOST_CORE_SNPRINTF( buffer, "%lu", static_cast< unsigned long >( n ) );
 
     return buffer;
 }
+
+#undef BOOST_CORE_SNPRINTF
 
 #if defined(BOOST_MSVC)
 # pragma warning( pop )


### PR DESCRIPTION
Use same method as https://github.com/boostorg/assert/commit/601ee4ba7ae9d9b532dab5f7e757f4187dce6300. 