### PR TITLE
Deprecate `boost::core::is_same` and the associated header

### DIFF
--- a/doc/changes.qbk
+++ b/doc/changes.qbk
@@ -11,6 +11,9 @@
 
 * Added [link core.snprintf `boost/core/snprintf.hpp`] header with portable definitions of `snprintf`, `vsnprintf` and
   their `wchar_t` counterparts.
+* Deprecated `boost/core/is_same.hpp` and `boost::core::is_same`. The header will be removed in a future release.
+  Users are advised to use [@http://www.boost.org/doc/libs/release/libs/type_traits/doc/html/index.html Boost.TypeTraits]
+  or C++ standard library type traits instead.
 
 [endsect]
 

--- a/doc/is_same.qbk
+++ b/doc/is_same.qbk
@@ -17,6 +17,11 @@
 
 [section Header <boost/core/is_same.hpp>]
 
+[warning This component is deprecated and will be removed in a future release.
+Users are recommended to use `boost::is_same` from
+[@http://www.boost.org/doc/libs/release/libs/type_traits/doc/html/index.html Boost.TypeTraits]
+or `std::is_same` from C++ standard library `<type_traits>` instead.]
+
 The header `<boost/core/is_same.hpp>` defines the class template
 `boost::core::is_same<T1,T2>`. It defines a nested integral constant
 `value` which is `true` when `T1` and `T2` are the same type, and

--- a/doc/lightweight_test.qbk
+++ b/doc/lightweight_test.qbk
@@ -326,14 +326,14 @@ parentheses.)
 
 ``
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 template<class T, class U> struct X
 {
     typedef T type;
 };
 
-using boost::core::is_same;
+using boost::is_same;
 
 int main()
 {

--- a/include/boost/core/detail/is_same.hpp
+++ b/include/boost/core/detail/is_same.hpp
@@ -1,0 +1,39 @@
+#ifndef BOOST_CORE_DETAIL_IS_SAME_HPP_INCLUDED
+#define BOOST_CORE_DETAIL_IS_SAME_HPP_INCLUDED
+
+// is_same<T1,T2>::value is true when T1 == T2
+//
+// Copyright 2014 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+#endif
+
+namespace boost
+{
+namespace core
+{
+namespace detail
+{
+
+template< class T1, class T2 > struct is_same
+{
+    BOOST_STATIC_CONSTANT( bool, value = false );
+};
+
+template< class T > struct is_same< T, T >
+{
+    BOOST_STATIC_CONSTANT( bool, value = true );
+};
+
+} // namespace detail
+} // namespace core
+} // namespace boost
+
+#endif // #ifndef BOOST_CORE_DETAIL_IS_SAME_HPP_INCLUDED

--- a/include/boost/core/detail/string_view.hpp
+++ b/include/boost/core/detail/string_view.hpp
@@ -14,7 +14,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/core/enable_if.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/core/detail/is_same.hpp>
 #include <boost/assert.hpp>
 #include <boost/assert/source_location.hpp>
 #include <boost/throw_exception.hpp>
@@ -381,7 +381,7 @@ public:
     }
 
     template<class End> BOOST_CXX14_CONSTEXPR basic_string_view( Ch const* first, End last,
-        typename boost::enable_if<is_same<End, Ch const*> >::type* = 0 ) BOOST_NOEXCEPT: p_( first ), n_( last - first )
+        typename boost::enable_if<boost::core::detail::is_same<End, Ch const*> >::type* = 0 ) BOOST_NOEXCEPT: p_( first ), n_( last - first )
     {
         BOOST_ASSERT( last - first >= 0 );
     }
@@ -399,7 +399,7 @@ public:
 #endif
 
     template<class Ch2> basic_string_view( boost::basic_string_view<Ch2, std::char_traits<Ch2> > const& str,
-        typename boost::enable_if<is_same<Ch, Ch2> >::type* = 0 ) BOOST_NOEXCEPT: p_( str.data() ), n_( str.size() )
+        typename boost::enable_if<boost::core::detail::is_same<Ch, Ch2> >::type* = 0 ) BOOST_NOEXCEPT: p_( str.data() ), n_( str.size() )
     {
     }
 
@@ -430,7 +430,7 @@ public:
 
 #if !defined(BOOST_NO_CXX17_HDR_STRING_VIEW)
 
-    template<class Ch2, class En = typename boost::enable_if<is_same<Ch2, Ch> >::type>
+    template<class Ch2, class En = typename boost::enable_if<boost::core::detail::is_same<Ch2, Ch> >::type>
     operator std::basic_string_view<Ch2>() const BOOST_NOEXCEPT
     {
         return std::basic_string_view<Ch>( data(), size() );
@@ -439,7 +439,7 @@ public:
 #endif
 
     template<class Ch2> operator boost::basic_string_view<Ch2,
-        typename boost::enable_if<boost::core::is_same<Ch2, Ch>, std::char_traits<Ch> >::type> () const BOOST_NOEXCEPT
+        typename boost::enable_if<boost::core::detail::is_same<Ch2, Ch>, std::char_traits<Ch> >::type> () const BOOST_NOEXCEPT
     {
         return boost::basic_string_view< Ch, std::char_traits<Ch> >( data(), size() );
     }
@@ -605,7 +605,7 @@ public:
         if( cmp != 0 ) return cmp;
 
         if( size() == str.size() ) return 0;
-        
+
         return size() < str.size()? -1: +1;
     }
 

--- a/include/boost/core/is_same.hpp
+++ b/include/boost/core/is_same.hpp
@@ -1,12 +1,6 @@
 #ifndef BOOST_CORE_IS_SAME_HPP_INCLUDED
 #define BOOST_CORE_IS_SAME_HPP_INCLUDED
 
-// MS compatible compilers support #pragma once
-
-#if defined(_MSC_VER) && (_MSC_VER >= 1020)
-# pragma once
-#endif
-
 // is_same<T1,T2>::value is true when T1 == T2
 //
 // Copyright 2014 Peter Dimov
@@ -16,6 +10,15 @@
 // http://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/config.hpp>
+#include <boost/core/detail/is_same.hpp>
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+#endif
+
+#include <boost/config/header_deprecated.hpp>
+
+BOOST_HEADER_DEPRECATED("<boost/type_traits/is_same.hpp>")
 
 namespace boost
 {
@@ -23,15 +26,7 @@ namespace boost
 namespace core
 {
 
-template< class T1, class T2 > struct is_same
-{
-    BOOST_STATIC_CONSTANT( bool, value = false );
-};
-
-template< class T > struct is_same< T, T >
-{
-    BOOST_STATIC_CONSTANT( bool, value = true );
-};
+using boost::core::detail::is_same;
 
 } // namespace core
 

--- a/include/boost/core/lightweight_test_trait.hpp
+++ b/include/boost/core/lightweight_test_trait.hpp
@@ -22,7 +22,7 @@
 
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/type_name.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/core/detail/is_same.hpp>
 #include <boost/config.hpp>
 
 namespace boost
@@ -56,7 +56,7 @@ template<class T> inline bool test_trait_same_impl_( T )
 }
 
 template<class T1, class T2> inline void test_trait_same_impl( char const * types,
-  boost::core::is_same<T1, T2> same, char const * file, int line, char const * function )
+  boost::core::detail::is_same<T1, T2> same, char const * file, int line, char const * function )
 {
     if( test_trait_same_impl_( same ) )
     {
@@ -86,6 +86,6 @@ template<class T1, class T2> inline void test_trait_same_impl( char const * type
 # pragma GCC system_header
 #endif
 
-#define BOOST_TEST_TRAIT_SAME(...) ( ::boost::detail::test_trait_same_impl(#__VA_ARGS__, ::boost::core::is_same<__VA_ARGS__>(), __FILE__, __LINE__, BOOST_CURRENT_FUNCTION) )
+#define BOOST_TEST_TRAIT_SAME(...) ( ::boost::detail::test_trait_same_impl(#__VA_ARGS__, ::boost::core::detail::is_same< __VA_ARGS__ >(), __FILE__, __LINE__, BOOST_CURRENT_FUNCTION) )
 
 #endif // #ifndef BOOST_CORE_LIGHTWEIGHT_TEST_TRAIT_HPP

--- a/include/boost/core/type_name.hpp
+++ b/include/boost/core/type_name.hpp
@@ -14,7 +14,6 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/core/demangle.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/config.hpp>
 #include <string>
 #include <functional>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
 
 if(HAVE_BOOST_TEST)
 
-boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::core Boost::static_assert)
+boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::core Boost::static_assert Boost::type_traits)
 
 set(BOOST_TEST_LINK_LIBRARIES Boost::core Boost::type_traits)
 

--- a/test/allocator_const_pointer_test.cpp
+++ b/test/allocator_const_pointer_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -22,9 +22,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::allocator_const_pointer<A1<char> >::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int*,
         boost::allocator_const_pointer<A2<int> >::type>));
     return boost::report_errors();
 }

--- a/test/allocator_const_void_pointer_test.cpp
+++ b/test/allocator_const_void_pointer_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -27,9 +27,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::allocator_const_void_pointer<A1<char> >::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const void*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const void*,
         boost::allocator_const_void_pointer<A2<int> >::type>));
     return boost::report_errors();
 }

--- a/test/allocator_difference_type_test.cpp
+++ b/test/allocator_difference_type_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -22,9 +22,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<short,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<short,
         boost::allocator_difference_type<A1<char> >::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::allocator_difference_type<A2<int> >::type>));
     return boost::report_errors();
 }

--- a/test/allocator_is_always_equal_test.cpp
+++ b/test/allocator_is_always_equal_test.cpp
@@ -6,7 +6,6 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
 template<class T>

--- a/test/allocator_pocca_test.cpp
+++ b/test/allocator_pocca_test.cpp
@@ -6,7 +6,6 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
 template<class T>

--- a/test/allocator_pocma_test.cpp
+++ b/test/allocator_pocma_test.cpp
@@ -6,7 +6,6 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
 template<class T>

--- a/test/allocator_pocs_test.cpp
+++ b/test/allocator_pocs_test.cpp
@@ -6,7 +6,6 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
 template<class T>

--- a/test/allocator_pointer_test.cpp
+++ b/test/allocator_pointer_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -22,9 +22,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::allocator_pointer<A1<char> >::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::allocator_pointer<A2<int> >::type>));
     return boost::report_errors();
 }

--- a/test/allocator_rebind_test.cpp
+++ b/test/allocator_rebind_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -25,9 +25,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<A1<int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<A1<int>,
         boost::allocator_rebind<A1<char>, bool>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<A2<int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<A2<int>,
         boost::allocator_rebind<A2<char>, int>::type>));
     return boost::report_errors();
 }

--- a/test/allocator_size_type_test.cpp
+++ b/test/allocator_size_type_test.cpp
@@ -6,8 +6,11 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/type_traits/is_same.hpp>
+#if !defined(BOOST_NO_CXX11_ALLOCATOR)
+#include <boost/type_traits/make_unsigned.hpp>
+#endif
 
 template<class T>
 struct A1 {
@@ -24,11 +27,11 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<int,
         boost::allocator_size_type<A1<char> >::type>));
 #if !defined(BOOST_NO_CXX11_ALLOCATOR)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<
-        std::make_unsigned<std::ptrdiff_t>::type,
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<
+        boost::make_unsigned<std::ptrdiff_t>::type,
         boost::allocator_size_type<A2<int> >::type>));
 #endif
     return boost::report_errors();

--- a/test/allocator_value_type_test.cpp
+++ b/test/allocator_value_type_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A {
@@ -16,7 +16,7 @@ struct A {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::allocator_value_type<A<int> >::type>));
     return boost::report_errors();
 }

--- a/test/allocator_void_pointer_test.cpp
+++ b/test/allocator_void_pointer_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct A1 {
@@ -27,9 +27,9 @@ struct A2 {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::allocator_void_pointer<A1<char> >::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void*,
         boost::allocator_void_pointer<A2<int> >::type>));
     return boost::report_errors();
 }

--- a/test/detail_iterator_test.cpp
+++ b/test/detail_iterator_test.cpp
@@ -10,8 +10,8 @@
 
 #define BOOST_ALLOW_DEPRECATED_HEADERS
 #include <boost/detail/iterator.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <cstddef>
 #include <list>
 
@@ -62,7 +62,7 @@ struct iterator
 
 int main()
 {
-    using boost::core::is_same;
+    using boost::is_same;
 
 /*
     template<class Iterator> struct iterator_traits {

--- a/test/eif_lazy_test.cpp
+++ b/test/eif_lazy_test.cpp
@@ -12,7 +12,7 @@
 
 // Testing all variations of lazy_enable_if.
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/core/lightweight_test.hpp>
 
@@ -26,7 +26,7 @@ using boost::lazy_disable_if_c;
 template <class T>
 struct is_int_or_double {
   BOOST_STATIC_CONSTANT(bool, 
-    value = (boost::is_same<T, int>::value || 
+    value = (boost::is_same<T, int>::value ||
              boost::is_same<T, double>::value));
 };
 
@@ -84,14 +84,14 @@ int main()
   BOOST_TEST(foo(1));
   BOOST_TEST(foo(1.0));
 
-  BOOST_TEST(!foo("1"));  
-  BOOST_TEST(!foo(static_cast<void*>(0)));  
+  BOOST_TEST(!foo("1"));
+  BOOST_TEST(!foo(static_cast<void*>(0)));
 
   BOOST_TEST(foo2(1));
   BOOST_TEST(foo2(1.0));
 
-  BOOST_TEST(!foo2("1"));  
-  BOOST_TEST(!foo2(static_cast<void*>(0)));  
+  BOOST_TEST(!foo2("1"));
+  BOOST_TEST(!foo2(static_cast<void*>(0)));
 
   return boost::report_errors();
 }

--- a/test/is_same_test.cpp
+++ b/test/is_same_test.cpp
@@ -1,5 +1,5 @@
 //
-// Test for core::is_same<T1,T2>
+// Test for core::detail::is_same<T1,T2>
 //
 // Copyright 2014 Peter Dimov
 //
@@ -8,7 +8,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/core/is_same.hpp>
+#include <boost/core/detail/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
 struct X
@@ -21,18 +21,18 @@ struct Y
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE(( boost::core::is_same<X, X> ));
-    BOOST_TEST_TRAIT_TRUE(( boost::core::is_same<Y, Y> ));
-    BOOST_TEST_TRAIT_TRUE(( boost::core::is_same<void, void> ));
-    BOOST_TEST_TRAIT_TRUE(( boost::core::is_same<int, int> ));
-    BOOST_TEST_TRAIT_TRUE(( boost::core::is_same<void const volatile, void const volatile> ));
+    BOOST_TEST_TRAIT_TRUE(( boost::core::detail::is_same<X, X> ));
+    BOOST_TEST_TRAIT_TRUE(( boost::core::detail::is_same<Y, Y> ));
+    BOOST_TEST_TRAIT_TRUE(( boost::core::detail::is_same<void, void> ));
+    BOOST_TEST_TRAIT_TRUE(( boost::core::detail::is_same<int, int> ));
+    BOOST_TEST_TRAIT_TRUE(( boost::core::detail::is_same<void const volatile, void const volatile> ));
 
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<X, Y> ));
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<X, X const> ));
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<X, void> ));
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<X, int> ));
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<int, void> ));
-    BOOST_TEST_TRAIT_FALSE(( boost::core::is_same<void, void const volatile> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<X, Y> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<X, X const> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<X, void> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<X, int> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<int, void> ));
+    BOOST_TEST_TRAIT_FALSE(( boost::core::detail::is_same<void, void const volatile> ));
 
     return boost::report_errors();
 }

--- a/test/iterator_test.cpp
+++ b/test/iterator_test.cpp
@@ -18,8 +18,8 @@
 #if BOOST_CXX_VERSION < 201703
 
 #include <boost/iterator.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 /*
 
@@ -60,7 +60,7 @@ struct R
 
 int main()
 {
-    using boost::core::is_same;
+    using boost::is_same;
 
     BOOST_TEST_TRAIT_TRUE((is_same<boost::iterator<C,T,D,P,R>::iterator_category,C>));
     BOOST_TEST_TRAIT_TRUE((is_same<boost::iterator<C,T,D,P,R>::value_type,T>));

--- a/test/pointer_traits_difference_type_test.cpp
+++ b/test/pointer_traits_difference_type_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/pointer_traits.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct P { };
@@ -19,23 +19,23 @@ struct E {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<int*>::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<P<int> >::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<long,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<long,
         boost::pointer_traits<E<int> >::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<void*>::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<P<void> >::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<long,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<long,
         boost::pointer_traits<E<void> >::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<const int*>::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<std::ptrdiff_t,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<std::ptrdiff_t,
         boost::pointer_traits<P<const int> >::difference_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<long,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<long,
         boost::pointer_traits<E<const int> >::difference_type>));
     return boost::report_errors();
 }

--- a/test/pointer_traits_element_type_test.cpp
+++ b/test/pointer_traits_element_type_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/pointer_traits.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct P1 { };
@@ -45,39 +45,39 @@ struct E {
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::pointer_traits<int*>::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::pointer_traits<P1<int> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::pointer_traits<P2<int, char> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::pointer_traits<P3<int, char, char> >::element_type>));
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int,
         boost::pointer_traits<P<int, char, char, char> >::element_type>));
 #endif
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E1<int> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E2<int, int> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E3<int, int, int> >::element_type>));
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E<int, int, int, int> >::element_type>));
 #endif
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void,
         boost::pointer_traits<void*>::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void,
         boost::pointer_traits<P1<void> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E1<void> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int,
         boost::pointer_traits<const int*>::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int,
         boost::pointer_traits<P1<const int> >::element_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<bool,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<bool,
         boost::pointer_traits<E1<const int> >::element_type>));
     return boost::report_errors();
 }

--- a/test/pointer_traits_pointer_test.cpp
+++ b/test/pointer_traits_pointer_test.cpp
@@ -6,25 +6,25 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/pointer_traits.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct P { };
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::pointer_traits<int*>::pointer>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P<int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P<int>,
         boost::pointer_traits<P<int> >::pointer>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void*,
         boost::pointer_traits<void*>::pointer>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P<void>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P<void>,
         boost::pointer_traits<P<void> >::pointer>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int*,
         boost::pointer_traits<const int*>::pointer>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P<const int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P<const int>,
         boost::pointer_traits<P<const int> >::pointer>));
     return boost::report_errors();
 }

--- a/test/pointer_traits_rebind_test.cpp
+++ b/test/pointer_traits_rebind_test.cpp
@@ -6,8 +6,8 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/core/pointer_traits.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <boost/core/detail/is_same.hpp>
 
 template<class T>
 struct P1 { };
@@ -55,94 +55,94 @@ struct R { };
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<char*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<char*,
         boost::pointer_traits<R*>::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<char>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<char>,
         boost::pointer_traits<P1<R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P2<char, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P2<char, R>,
         boost::pointer_traits<P2<R, R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P3<char, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P3<char, R, R>,
         boost::pointer_traits<P3<R, R, R> >::rebind_to<char>::type>));
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P<char, R, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P<char, R, R, R>,
         boost::pointer_traits<P<R, R, R, R> >::rebind_to<char>::type>));
 #endif
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void*,
         boost::pointer_traits<R*>::rebind_to<void>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<void>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<void>,
         boost::pointer_traits<P1<R> >::rebind_to<void>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<R*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<R*,
         boost::pointer_traits<void*>::rebind_to<R>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<R>,
         boost::pointer_traits<P1<void> >::rebind_to<R>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int*,
         boost::pointer_traits<R*>::rebind_to<const int>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<const int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<const int>,
         boost::pointer_traits<P1<R> >::rebind_to<const int>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::pointer_traits<const R*>::rebind_to<int>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<int>,
         boost::pointer_traits<P1<const R> >::rebind_to<int>::type>));
 #if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<char*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<char*,
         boost::pointer_traits<R*>::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<char>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<char>,
         boost::pointer_traits<P1<R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P2<char, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P2<char, R>,
         boost::pointer_traits<P2<R, R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P3<char, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P3<char, R, R>,
         boost::pointer_traits<P3<R, R, R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<void*,
         boost::pointer_traits<R*>::rebind<void> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<void>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<void>,
         boost::pointer_traits<P1<R> >::rebind<void> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<R*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<R*,
         boost::pointer_traits<void*>::rebind<R> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<R>,
         boost::pointer_traits<P1<void> >::rebind<R> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<const int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<const int*,
         boost::pointer_traits<R*>::rebind<const int> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<const int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<const int>,
         boost::pointer_traits<P1<R> >::rebind<const int> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int*,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<int*,
         boost::pointer_traits<const R*>::rebind<int> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P1<int>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P1<int>,
         boost::pointer_traits<P1<const R> >::rebind<int> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E2<bool, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E2<bool, R>,
         boost::pointer_traits<E2<R, R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E3<bool, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E3<bool, R, R>,
         boost::pointer_traits<E3<R, R, R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E2<bool, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E2<bool, R>,
         boost::pointer_traits<E2<R, R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E3<bool, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E3<bool, R, R>,
         boost::pointer_traits<E3<R, R, R> >::rebind<char> >));
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<P<char, R, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<P<char, R, R, R>,
         boost::pointer_traits<P<R, R, R, R> >::rebind<char> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E<bool, R, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E<bool, R, R, R>,
         boost::pointer_traits<E<R, R, R, R> >::rebind_to<char>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E<bool, R, R, R>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E<bool, R, R, R>,
         boost::pointer_traits<E<R, R, R, R> >::rebind<char> >));
 #endif
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind_to<void>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<void> >::rebind_to<R>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind_to<const int>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<const R> >::rebind_to<int>::type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind<void> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<void> >::rebind<R> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<R> >::rebind<const int> >));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<E1<bool>,
+    BOOST_TEST_TRAIT_TRUE((boost::core::detail::is_same<E1<bool>,
         boost::pointer_traits<E1<const R> >::rebind<int> >));
 #endif
     return boost::report_errors();

--- a/test/quick.cpp
+++ b/test/quick.cpp
@@ -16,13 +16,12 @@
 #include <boost/core/explicit_operator_bool.hpp>
 #include <boost/get_pointer.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/core/null_deleter.hpp>
 #include <boost/core/fclose_deleter.hpp>
 #include <boost/core/pointer_traits.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/core/scoped_enum.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/core/underlying_type.hpp>

--- a/test/ref_ct_test.cpp
+++ b/test/ref_ct_test.cpp
@@ -6,10 +6,10 @@
 // compile-time test for "boost/ref.hpp" header content
 // see 'ref_test.cpp' for run-time part
 
-#include <boost/ref.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/config/workaround.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 namespace {
 
@@ -17,8 +17,8 @@ template< typename T, typename U >
 void ref_test(boost::reference_wrapper<U>)
 {
     typedef typename boost::reference_wrapper<U>::type type;
-    BOOST_STATIC_ASSERT((boost::core::is_same<U,type>::value));
-    BOOST_STATIC_ASSERT((boost::core::is_same<T,type>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<U,type>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<T,type>::value));
 }
 
 template< typename T >
@@ -42,14 +42,14 @@ void is_reference_wrapper_test(T)
 template< typename R, typename Ref >
 void cxx_reference_test(Ref)
 {
-    BOOST_STATIC_ASSERT((boost::core::is_same<R,Ref>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<R,Ref>::value));
 }
 
 template< typename R, typename Ref >
 void unwrap_reference_test(Ref)
 {
     typedef typename boost::unwrap_reference<Ref>::type type;
-    BOOST_STATIC_ASSERT((boost::core::is_same<R,type>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<R,type>::value));
 }
 
 } // namespace

--- a/test/ref_test.cpp
+++ b/test/ref_test.cpp
@@ -6,7 +6,7 @@
 // run-time test for "boost/ref.hpp" header content
 // see 'ref_ct_test.cpp' for compile-time part
 
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 namespace {

--- a/test/sv_types_test.cpp
+++ b/test/sv_types_test.cpp
@@ -5,7 +5,6 @@
 #include <boost/core/detail/string_view.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/core/is_same.hpp>
 #include <iterator>
 
 struct Ch

--- a/test/underlying_type.cpp
+++ b/test/underlying_type.cpp
@@ -15,7 +15,7 @@
 #include <boost/core/underlying_type.hpp>
 #include <boost/core/scoped_enum.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/config.hpp>
 
 #if defined(_MSC_VER)
@@ -63,9 +63,9 @@ struct underlying_type< native_enum >
 
 int main(int, char*[])
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same< boost::underlying_type< emulated_enum >::type, unsigned char >));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same< boost::underlying_type< emulated_enum >::type, unsigned char >));
 #if !defined(BOOST_NO_CXX11_SCOPED_ENUMS)
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same< boost::underlying_type< native_enum >::type, unsigned short >));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same< boost::underlying_type< native_enum >::type, unsigned short >));
 #endif
 
     return boost::report_errors();


### PR DESCRIPTION
Moved `is_same` implementation to detail (both directory and namespace) to use in the public headers and avoid introducing new dependencies. All other uses were ported to Boost.TypeTraits. Likewise, the documentation now recommends users to use Boost.TypeTraits or C++ standard library instead.

Also, removed unnecessary includes and added missing ones in a few places.