### PR TITLE
Implement latch

### DIFF
--- a/doc/core.qbk
+++ b/doc/core.qbk
@@ -83,3 +83,4 @@ criteria for inclusion is that the utility component be:
 [include uncaught_exceptions.qbk]
 [include use_default.qbk]
 [include verbose_terminate_handler.qbk]
+[include latch.qbk]

--- a/doc/latch.qbk
+++ b/doc/latch.qbk
@@ -1,0 +1,164 @@
+[/
+  Copyright 2023 Christian Mazakas
+  Distributed under the Boost Software License, Version 1.0.
+  https://boost.org/LICENSE_1_0.txt
+]
+
+[section:latch latch]
+
+[simplesect Authors]
+
+* Christian Mazakas
+
+[endsimplesect]
+
+[section Header <boost/core/latch.hpp>]
+
+The header `<boost/core/latch.hpp>` implements, in a portable way,
+the C++20 `<latch>` header.
+
+`latch` is a single-use barrier which counts downwards, enabling synchronization
+between a set of threads. The counter can be manually decremented by any value,
+but decrementing below zero produces UB. The maximum number of waiters is
+specified to be `boost::core::latch::max()`.
+
+[endsect]
+
+[section Example]
+
+```
+std::ptrdiff_t const num_threads = 16;
+boost::core::latch l(num_threads);
+
+std::vector<std::thread> threads;
+for (int i = 0; i < num_threads; ++i) {
+  threads.emplace_back([&l] {
+    // block until all threads have reached this statement
+    l.arrive_and_wait();
+  });
+}
+
+for (auto& t: threads) { t.join(); }
+```
+
+[endsect]
+
+[section Reference]
+
+```
+namespace boost
+{
+namespace core
+{
+
+class latch
+{
+    explicit latch(std::ptrdiff_t expected);
+
+    latch(latch const &) = delete;
+    latch &operator=(latch const &) = delete;
+
+    ~latch() = default;
+
+    void count_down(std::ptrdiff_t n = 1);
+
+    bool try_wait() const noexcept;
+
+    void wait() const;
+
+    void arrive_and_wait(std::ptrdiff_t n = 1);
+
+    static constexpr std::ptrdiff_t max() noexcept;
+};
+
+} // namespace core
+} // namespace boost
+```
+
+[section Constructors]
+
+[variablelist
+  [
+    [`explicit latch(std::ptrdiff_t expected);`]
+    [
+      [variablelist
+        [[Constraints][`expected >= 0 && expected <= boost::core::latch::max()`.]]
+        [
+          [Effects]
+          [Constructs a latch with an internal counter value of `expected`.]
+        ]
+      ]
+    ]
+  ]
+  [
+    [`latch(latch const &) = delete;`]
+    [
+      [variablelist
+        [[Constraints][`latch` is not copyable or movable.]]
+      ]
+    ]
+  ]
+]
+
+[endsect]
+
+[section Member Functions]
+
+[variablelist
+  [
+    [`void count_down(std::ptrdiff_t n = 1);`]
+    [
+      [variablelist
+        [[Constraints][`n` must not be larger than the current internal count.]]
+        [[Effects][Decrements the internal counter by `n`.]]
+      ]
+    ]
+  ]
+  [
+    [`bool try_wait() const noexcept;`]
+    [
+      [variablelist
+        [[Effects][Returns a boolean indicating whether or not the latch's internal count has reached 0 (`true`) or not (`false`).]]
+      ]
+    ]
+  ]
+  [
+    [`void wait() const;`]
+    [
+      [variablelist
+        [[Effects][Blocks the current thread until the internal counter has reached 0.]]
+      ]
+    ]
+  ]
+    [
+    [`void wait() const;`]
+    [
+      [variablelist
+        [[Effects][Blocks the current thread until the internal counter has reached 0.]]
+      ]
+    ]
+  ]
+  [
+    [`void arrive_and_wait(std::ptrdiff_t n = 1);`]
+    [
+      [variablelist
+        [[Constraints][`n` must not be larger than the current internal count.]]
+        [[Effects][Decrements the internal counter by `n` and if the counter non-zero, blocks the current thread.]]
+      ]
+    ]
+  ]
+  [
+    [`static constexpr std::ptrdiff_t max() noexcept;`]
+    [
+      [variablelist
+        [[Effects][Returns an implementation-defined number representing the maximum amount of waiters. Currently INT_MAX.]]
+      ]
+    ]
+  ]
+]
+
+[endsect]
+
+[endsect]
+
+[endsect]

--- a/include/boost/core/latch.hpp
+++ b/include/boost/core/latch.hpp
@@ -1,0 +1,104 @@
+//  Copyright 2023 Christian Mazakas
+//  Distributed under the Boost Software License, Version 1.0.
+//  https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_CORE_LATCH_HPP_INCLUDED
+#define BOOST_CORE_LATCH_HPP_INCLUDED
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_NO_CXX11_HDR_CONDITION_VARIABLE)
+BOOST_PRAGMA_MESSAGE("boost::core::latch requires <condition_variable>")
+#elif defined(BOOST_NO_CXX11_HDR_MUTEX)
+BOOST_PRAGMA_MESSAGE("boost::core::latch requies <mutex>")
+#else
+
+#include <boost/assert.hpp>
+
+#include <climits>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+
+namespace boost
+{
+namespace core
+{
+class latch
+{
+private:
+    std::ptrdiff_t n_;
+    mutable std::mutex m_;
+    mutable std::condition_variable cv_;
+
+public:
+    explicit latch(std::ptrdiff_t expected) : n_{expected}, m_{}, cv_{}
+    {
+        BOOST_ASSERT(n_ >= 0);
+        BOOST_ASSERT(n_ <= max());
+    }
+
+    latch(latch const &) = delete;
+    latch &operator=(latch const &) = delete;
+
+    ~latch() = default;
+
+    void count_down(std::ptrdiff_t n = 1)
+    {
+        std::unique_lock<std::mutex> lk(m_);
+        count_down_and_notify(lk, n);
+    }
+
+    bool try_wait() const noexcept
+    {
+        std::unique_lock<std::mutex> lk(m_);
+        return is_ready();
+    }
+
+    void wait() const
+    {
+        std::unique_lock<std::mutex> lk(m_);
+        wait_impl(lk);
+    }
+
+    void arrive_and_wait(std::ptrdiff_t n = 1)
+    {
+        std::unique_lock<std::mutex> lk(m_);
+        bool should_wait = count_down_and_notify(lk, n);
+        if (should_wait)
+        {
+            wait_impl(lk);
+        }
+    }
+
+    static constexpr std::ptrdiff_t max() noexcept { return INT_MAX; }
+
+private:
+    bool is_ready() const { return n_ == 0; }
+
+    bool count_down_and_notify(
+        std::unique_lock<std::mutex> &lk, std::ptrdiff_t n)
+    {
+        n_ -= n;
+        if (n_ == 0)
+        {
+            lk.unlock();
+            cv_.notify_all();
+            return false;
+        }
+
+        return true;
+    }
+
+    void wait_impl(std::unique_lock<std::mutex> &lk) const
+    {
+        cv_.wait(lk, [this]
+                    { return this->is_ready(); });
+    }
+};
+}
+}
+
+#endif
+
+#endif // BOOST_CORE_LATCH_HPP_INCLUDED

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -371,5 +371,7 @@ run serialization_construct_data_test.cpp : : : <library>/boost//serialization/<
 run identity_test.cpp ;
 run identity_rvalue_test.cpp ;
 
+run latch_test.cpp ;
+
 use-project /boost/core/swap : ./swap ;
 build-project ./swap ;

--- a/test/latch_test.cpp
+++ b/test/latch_test.cpp
@@ -1,0 +1,178 @@
+//  Copyright 2023 Christian Mazakas
+//  Distributed under the Boost Software License, Version 1.0.
+//  https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config.hpp>
+#include <boost/config/pragma_message.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_CONDITION_VARIABLE) && !defined(BOOST_NO_CXX11_HDR_MUTEX)
+
+#define BOOST_ENABLE_ASSERT_HANDLER
+
+#include <boost/core/latch.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+#include <thread>
+#include <vector>
+
+struct exception
+{
+};
+
+namespace boost
+{
+    void assertion_failed(
+        char const *expr, char const *function, char const *file, long line)
+    {
+        (void)expr;
+        (void)function;
+        (void)file;
+        (void)line;
+        throw exception{};
+    }
+} // namespace boost
+
+namespace
+{
+    void test_max() { BOOST_TEST_EQ(boost::core::latch::max(), INT_MAX); }
+
+    void test_constructor()
+    {
+        {
+            auto const f = []
+            {
+                boost::core::latch l(-1);
+                (void)l;
+            };
+            BOOST_TEST_THROWS(f(), exception);
+        }
+
+        {
+            std::ptrdiff_t n = 0;
+
+            boost::core::latch l(n);
+            BOOST_TEST(l.try_wait());
+        }
+
+        {
+            std::ptrdiff_t n = 16;
+
+            boost::core::latch l(n);
+            BOOST_TEST_NOT(l.try_wait());
+
+            l.count_down(16);
+            BOOST_TEST(l.try_wait());
+        }
+
+#if PTRDIFF_MAX > INT_MAX
+        {
+            auto const f = []
+            {
+                std::ptrdiff_t n = INT_MAX;
+                n += 10;
+                boost::core::latch l(n);
+                (void)l;
+            };
+            BOOST_TEST_THROWS(f(), exception);
+        }
+#endif
+    }
+
+    void test_count_down_and_wait()
+    {
+        constexpr std::ptrdiff_t n = 1024;
+
+        boost::core::latch l(2 * n);
+
+        bool bs[] = {false, false};
+
+        std::thread t1([&]
+                       {
+      l.wait();
+      BOOST_TEST(bs[0]);
+      BOOST_TEST(bs[1]); });
+
+        std::thread t2([&]
+                       {
+      for (int i = 0; i < n; ++i) {
+        if (i == (n - 1)) {
+          bs[0] = true;
+        } else {
+          BOOST_TEST_NOT(l.try_wait());
+        }
+
+        l.count_down(1);
+      } });
+
+        for (int i = 0; i < n; ++i)
+        {
+            if (i == (n - 1))
+            {
+                bs[1] = true;
+            }
+            else
+            {
+                BOOST_TEST_NOT(l.try_wait());
+            }
+
+            l.count_down(1);
+        }
+
+        t1.join();
+        t2.join();
+
+        BOOST_TEST(l.try_wait());
+    }
+
+    void test_arrive_and_wait()
+    {
+        constexpr std::ptrdiff_t n = 16;
+
+        boost::core::latch l(2 * n);
+
+        int xs[n] = {0};
+
+        std::vector<std::thread> threads;
+        for (int i = 0; i < n; ++i)
+        {
+            threads.emplace_back([&l, &xs, i]
+                                 {
+        for (int j = 0; j < n; ++j) {
+          BOOST_TEST_EQ(xs[j], 0);
+        }
+
+        l.arrive_and_wait(2);
+
+        xs[i] = 1; });
+        }
+
+        for (auto &t : threads)
+        {
+            t.join();
+        }
+
+        for (int i = 0; i < n; ++i)
+        {
+            BOOST_TEST_EQ(xs[i], 1);
+        }
+    }
+} // namespace
+
+int main()
+{
+    test_max();
+    test_constructor();
+    test_count_down_and_wait();
+    test_arrive_and_wait();
+
+    return boost::report_errors();
+}
+
+#else
+
+BOOST_PRAGMA_MESSAGE("latch_test requires <mutex>, <condition_variable>")
+
+int main() { return 0; }
+
+#endif


### PR DESCRIPTION
Add an implementation of C++20's `std::latch`

https://en.cppreference.com/w/cpp/thread/latch

Note, notifying on the condition variable without the lock being held triggers a "dubious" warning from helgrind.