### PR TITLE
Fix Intel compiler build

### DIFF
--- a/include/boost/core/detail/sp_thread_pause.hpp
+++ b/include/boost/core/detail/sp_thread_pause.hpp
@@ -20,7 +20,7 @@
 #include <boost/config.hpp>
 
 #if defined(__has_builtin)
-# if __has_builtin(__builtin_ia32_pause) && !defined(_INTEL_COMPILER)
+# if __has_builtin(__builtin_ia32_pause) && !defined(__INTEL_COMPILER)
 #  define BOOST_CORE_HAS_BUILTIN_IA32_PAUSE
 # endif
 #endif


### PR DESCRIPTION
In building the Boost tests with the Intel compiler on Linux/amd64, I encountered this link error:
```
[ 10%] Linking CXX executable ../../../stage/bin/boost_core-yield_prim_pthread_cancel_test
icpc: warning #10182: disabling optimization; runtime debug checks enabled
CMakeFiles/boost_core-yield_prim_pthread_cancel_test.dir/yield_prim_pthread_cancel_test.cpp.o: In function `boost::core::sp_thread_pause()':
/tmp/boost/1.83.0/libs/core/include/boost/core/detail/sp_thread_pause.hpp:63: undefined reference to `__builtin_ia32_pause'
make[3]: *** [libs/core/test/CMakeFiles/boost_core-yield_prim_pthread_cancel_test.dir/build.make:97: stage/bin/boost_core-yield_prim_pthread_cancel_test] Error 1
make[2]: *** [CMakeFiles/Makefile2:12475: libs/core/test/CMakeFiles/boost_core-yield_prim_pthread_cancel_test.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:7316: CMakeFiles/tests.dir/rule] Error 2
make: *** [Makefile:427: tests] Error 2
```

I tracked this down to a typo: `__INTEL_COMPILER` should be prefixed by two underscores, not one. Every other instance of this symbol in the Boost source has two.