### PR TITLE
Fix `empty_value` MSVC bug

### DIFF
--- a/include/boost/core/empty_value.hpp
+++ b/include/boost/core/empty_value.hpp
@@ -96,6 +96,8 @@ private:
 
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
 #if defined(BOOST_MSVC)
+// This is a workaround to an MSVC bug when T is a nested class.
+// See https://developercommunity.visualstudio.com/t/Compiler-bug:-Incorrect-C2247-and-C2248/10690025
 namespace detail {
 
 template<class T>

--- a/include/boost/core/empty_value.hpp
+++ b/include/boost/core/empty_value.hpp
@@ -95,9 +95,53 @@ private:
 };
 
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+#if defined(BOOST_MSVC)
+namespace detail {
+
+template<class T>
+class empty_value_base
+    : public T {
+public:
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    empty_value_base() = default;
+#else
+    BOOST_CONSTEXPR empty_value_base() { }
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    template<class U, class... Args>
+    BOOST_CONSTEXPR empty_value_base(U&& value, Args&&... args)
+        : T(std::forward<U>(value), std::forward<Args>(args)...) { }
+#else
+    template<class U>
+    BOOST_CONSTEXPR empty_value_base(U&& value)
+        : T(std::forward<U>(value)) { }
+#endif
+#else
+    template<class U>
+    BOOST_CONSTEXPR empty_value_base(const U& value)
+        : T(value) { }
+
+    template<class U>
+    BOOST_CONSTEXPR empty_value_base(U& value)
+        : T(value) { }
+#endif
+};
+
+} /* detail */
+#endif
+
 template<class T, unsigned N>
 class empty_value<T, N, true>
+#if defined(BOOST_MSVC)
+    : detail::empty_value_base<T> {
+    typedef detail::empty_value_base<T> base;
+#else
     : T {
+    typedef T base;
+#endif
+
 public:
     typedef T type;
 
@@ -108,26 +152,26 @@ public:
 #endif
 
     BOOST_CONSTEXPR empty_value(boost::empty_init_t)
-        : T() { }
+        : base() { }
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     template<class U, class... Args>
     BOOST_CONSTEXPR empty_value(boost::empty_init_t, U&& value, Args&&... args)
-        : T(std::forward<U>(value), std::forward<Args>(args)...) { }
+        : base(std::forward<U>(value), std::forward<Args>(args)...) { }
 #else
     template<class U>
     BOOST_CONSTEXPR empty_value(boost::empty_init_t, U&& value)
-        : T(std::forward<U>(value)) { }
+        : base(std::forward<U>(value)) { }
 #endif
 #else
     template<class U>
     BOOST_CONSTEXPR empty_value(boost::empty_init_t, const U& value)
-        : T(value) { }
+        : base(value) { }
 
     template<class U>
     BOOST_CONSTEXPR empty_value(boost::empty_init_t, U& value)
-        : T(value) { }
+        : base(value) { }
 #endif
 
     BOOST_CONSTEXPR const T& get() const BOOST_NOEXCEPT {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -226,6 +226,7 @@ run empty_value_test.cpp ;
 run empty_value_size_test.cpp ;
 run empty_value_final_test.cpp ;
 run empty_value_constexpr_test.cpp ;
+compile-fail empty_value_compile_fail_casting.cpp ;
 
 run quick_exit_test.cpp ;
 run-fail quick_exit_fail.cpp ;

--- a/test/empty_value_compile_fail_casting.cpp
+++ b/test/empty_value_compile_fail_casting.cpp
@@ -1,0 +1,20 @@
+// Copyright 2024 Braden Ganetsky
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/core/empty_value.hpp>
+
+struct empty {};
+
+// This test ensures private inheritance of `boost::empty_value<T>` for empty `T`.
+// With public inheritance, `boost::empty_value<empty>*` could cast to `empty*`.
+void test_empty_not_convertible_to_base()
+{
+    const boost::empty_value<empty> x(boost::empty_init);
+    const empty* x2 = static_cast<const empty*>(&x);
+    (void)x2;
+}
+
+int main()
+{
+}

--- a/test/empty_value_test.cpp
+++ b/test/empty_value_test.cpp
@@ -79,6 +79,9 @@ struct outer {
 
 void test_derived_compile()
 {
+    // This is testing the workaround to an MSVC bug when T is a nested class.
+    // See https://developercommunity.visualstudio.com/t/Compiler-bug:-Incorrect-C2247-and-C2248/10690025
+
     const boost::empty_value<outer> x1(boost::empty_init);
     const boost::empty_value<outer::inner_empty> x2(boost::empty_init);
     const boost::empty_value<outer::inner_non_empty> x3(boost::empty_init);

--- a/test/empty_value_test.cpp
+++ b/test/empty_value_test.cpp
@@ -63,6 +63,37 @@ void test_type()
     BOOST_TEST(v2.get().value() == 6);
 }
 
+template <class T>
+struct derived : boost::empty_value<T> {
+    typedef typename boost::empty_value<T>::type type;
+    derived(boost::empty_init_t e) : boost::empty_value<T>(e) {}
+};
+
+struct outer {
+    struct inner_empty {};
+    struct inner_non_empty {
+        inner_non_empty() : value() {}
+        int value;
+    };
+};
+
+void test_derived_compile()
+{
+    const boost::empty_value<outer> x1(boost::empty_init);
+    const boost::empty_value<outer::inner_empty> x2(boost::empty_init);
+    const boost::empty_value<outer::inner_non_empty> x3(boost::empty_init);
+    const derived<outer> x4(boost::empty_init);
+    const derived<outer::inner_empty> x5(boost::empty_init);
+    const derived<outer::inner_non_empty> x6(boost::empty_init);
+
+    (void)x1;
+    (void)x2;
+    (void)x3;
+    (void)x4;
+    (void)x5;
+    (void)x6;
+}
+
 int main()
 {
     test_int();


### PR DESCRIPTION
See [unordered#257](https://github.com/boostorg/unordered/issues/257).

Is this a breaking change in Core? It doesn't break any tests, but is it conceptually wrong?