### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/core

--- a/build.jam
+++ b/build.jam
@@ -5,19 +5,22 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception ;
+
 project /boost/core
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
         <include>include
     ;
 
 explicit
-    [ alias boost_core ]
+    [ alias boost_core : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_core test ]
     ;
 
 call-if : boost-library core
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/core
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,23 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/core
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <include>include
+    ;
+
+explicit
+    [ alias boost_core ]
+    [ alias all : boost_core test ]
+    ;
+
+call-if : boost-library core
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,10 +7,10 @@ import project ;
 
 project /boost/core
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
         <include>include
     ;
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -9,7 +9,7 @@ import project ;
 import doxygen ;
 import quickbook ;
 
-path-constant INCLUDES : ../../.. ;
+path-constant INCLUDES : ../include ;
 
 doxygen ref_reference
   :

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import testing ;
 
 project : requirements
-  <source>/boost/type_traits//boost_type_traits
+  <library>/boost/type_traits//boost_type_traits
   <warnings>extra
   <toolset>msvc:<warnings-as-errors>on
   <toolset>clang:<warnings-as-errors>on

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,11 +6,14 @@
 #  See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import modules ;
 import testing ;
 
 project : requirements
-
+  <source>/boost/type_traits//boost_type_traits
   <warnings>extra
   <toolset>msvc:<warnings-as-errors>on
   <toolset>clang:<warnings-as-errors>on
@@ -194,7 +197,7 @@ run underlying_type.cpp ;
 compile-fail null_deleter_compile_fail_adl.cpp
   : $(warnings-as-errors-off) ;
 
-run fclose_deleter_test.cpp : : : <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS <target-os>windows:<define>_CRT_SECURE_NO_DEPRECATE ;
+run fclose_deleter_test.cpp /boost/move//boost_move /boost/smart_ptr//boost_smart_ptr : : : <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS <target-os>windows:<define>_CRT_SECURE_NO_DEPRECATE ;
 compile-fail fclose_deleter_compile_fail_adl.cpp
   : <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS <target-os>windows:<define>_CRT_SECURE_NO_DEPRECATE $(warnings-as-errors-off) ;
 
@@ -358,7 +361,7 @@ run sv_eq_test.cpp ;
 run sv_lt_test.cpp ;
 run sv_stream_insert_test.cpp ;
 run sv_conversion_test.cpp ;
-run sv_conversion_test2.cpp : ;
+run sv_conversion_test2.cpp /boost/utility//boost_utility : ;
 run sv_common_reference_test.cpp ;
 compile sv_common_reference_test2.cpp ;
 compile sv_windows_h_test.cpp ;
@@ -395,11 +398,9 @@ run memory_resource_test.cpp ;
 run data_test.cpp ;
 run size_test.cpp ;
 
-import ../../config/checks/config : requires ;
-
 local CPP11 = [ requires cxx11_variadic_templates cxx11_template_aliases cxx11_decltype cxx11_constexpr cxx11_noexcept ] ;
 
-local with-serialization = <library>/boost//serialization/<warnings>off $(warnings-as-errors-off) <undefined-sanitizer>norecover:<link>static $(CPP11) ;
+local with-serialization = <library>/boost/serialization//boost_serialization/<warnings>off <undefined-sanitizer>norecover:<link>static $(CPP11) ;
 
 run serialization_nvp_test.cpp : : : $(with-serialization) <undefined-sanitizer>norecover:<build>no ;
 run serialization_split_free_test.cpp : : : $(with-serialization) ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -382,7 +382,7 @@ run sv_stream_insert_test.cpp
   : : : $(pedantic-errors) ;
 run sv_conversion_test.cpp
   : : : $(pedantic-errors) ;
-run sv_conversion_test2.cpp : ;
+run sv_conversion_test2.cpp /boost/utility//boost_utility : ;
 run sv_common_reference_test.cpp
   : : : $(pedantic-errors) ;
 compile sv_common_reference_test2.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import modules ;
 import testing ;
 
 project : requirements
+  <library>/boost/core//boost_core
   <library>/boost/type_traits//boost_type_traits
   <warnings>extra
   <toolset>msvc:<warnings-as-errors>on

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -424,7 +424,7 @@ run size_test.cpp ;
 
 local CPP11 = [ requires cxx11_variadic_templates cxx11_template_aliases cxx11_decltype cxx11_constexpr cxx11_noexcept ] ;
 
-local with-serialization = <library>/boost/serialization//boost_serialization/<warnings>off <undefined-sanitizer>norecover:<link>static $(CPP11) ;
+local with-serialization = <library>/boost/serialization//boost_serialization/<warnings>off $(warnings-as-errors-off) <undefined-sanitizer>norecover:<link>static $(CPP11) ;
 
 run serialization_nvp_test.cpp : : : $(with-serialization) <undefined-sanitizer>norecover:<build>no ;
 run serialization_split_free_test.cpp : : : $(with-serialization) ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.