### PR TITLE
Remove <iterator> header from span.hpp

### DIFF
--- a/include/boost/core/span.hpp
+++ b/include/boost/core/span.hpp
@@ -10,7 +10,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/core/data.hpp>
 #include <array>
-#include <iterator>
+//#include <iterator>
 #include <type_traits>
 
 namespace boost {

--- a/include/boost/core/span.hpp
+++ b/include/boost/core/span.hpp
@@ -10,7 +10,6 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/core/data.hpp>
 #include <array>
-//#include <iterator>
 #include <type_traits>
 
 namespace boost {


### PR DESCRIPTION
edit: this description missed use of `std::reverse_iterator`, please see comments bellow

-----------------------------------


Due to reasons unrelated to this pull I was looking into how slow/fast to compile `span.hpp` and `<span>` are. 
I have noticed that `<span>` compiles faster and that preprocessed output (`-E` compiler flag) has around 20k lines less.
It turns our that is mostly due to include of `<iterator>` header. This measurement is limited to just my setup(libstdc++) and results may be different for some other std implementation.

As far as I know `<iterator>` is not needed for span functionality, and tests seem to pass. Note that I am not a boost dev so IDK how to properly test all users of this header, but for example I have tested beast beside running tests in core and all seems fine.

This is not super important change since huge percentage of users will eventually use some part of STL that will drag in `<iterator>` header, but I still believe we should fix this(if nothing is broken by this change) for 2 reasons:

1. There may be a small set of boost users that use only limited subset of boost/std and would appreciate this change. I do not know of any cases like this, but maybe some embedded or driver projects fits this description
2. I think in general it is nice to IWYU, even if as in this case most programs will still eventually include `<iterator>`
