### PR TITLE
Add checks for extent compatability in span range constructor

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -413,6 +413,11 @@ run as_bytes_test.cpp ;
 run as_writable_bytes_test.cpp ;
 compile span_boost_begin_test.cpp ;
 run make_span_test.cpp ;
+compile-fail span_incompatible_range_size_smaller.cpp ;
+compile-fail span_incompatible_range_size_larger.cpp ;
+compile span_compatible_range_size.cpp ;
+compile span_undetectable_incompatible_range_size.cpp ;
+compile span_default_constructed_size.cpp ;
 
 run splitmix64_test.cpp
   : : : $(pedantic-errors) ;

--- a/test/span_compatible_range_size.cpp
+++ b/test/span_compatible_range_size.cpp
@@ -1,0 +1,18 @@
+#include <boost/array.hpp>
+#include <boost/core/span.hpp>
+
+// use boost::array as generic range since span has no special handling for it,
+// unlike for std::array
+int main()
+{
+    boost::array<int, 0> arr0{};
+    boost::span<int, 0> sp0{arr0};
+    boost::span<const int, 0> csp0{arr0};
+    (void)sp0;
+    (void)csp0;
+    boost::array<int, 4> arr{};
+    boost::span<int, 4> sp{arr};
+    boost::span<const int, 4> csp{arr};
+    (void)sp;
+    (void)csp;
+}

--- a/test/span_default_constructed_size.cpp
+++ b/test/span_default_constructed_size.cpp
@@ -1,0 +1,57 @@
+#include <boost/core/span.hpp>
+#include <boost/static_assert.hpp>
+#include <thread>
+#include <type_traits>
+#include <vector>
+#if __cplusplus >= 202302L
+#include <span>
+#endif
+using namespace boost;
+
+// well known trick to make size() nicer.
+struct MyArray3 {
+    static constexpr std::integral_constant<std::size_t, 3> size{};
+};
+
+// tests for helper used in span range constructor
+int main()
+{
+    constexpr auto vec_size = detail::span_default_constructed_size<std::vector<int>>();
+    BOOST_STATIC_ASSERT(vec_size == 0);
+    constexpr auto str_size = detail::span_default_constructed_size<std::string>();
+    BOOST_STATIC_ASSERT(str_size == 0);
+    constexpr auto arr0_size = detail::span_default_constructed_size<std::array<int, 0>>();
+    BOOST_STATIC_ASSERT(arr0_size == 0);
+    constexpr auto arr1_size = detail::span_default_constructed_size<std::array<int, 1>>();
+    BOOST_STATIC_ASSERT(arr1_size == 1);
+    constexpr auto arr2_size = detail::span_default_constructed_size<std::array<int, 2>>();
+    BOOST_STATIC_ASSERT(arr2_size == 2);
+    constexpr auto non_constexpr_element_arr_size = detail::span_default_constructed_size<std::array<std::thread, 2>>();
+    BOOST_STATIC_ASSERT(non_constexpr_element_arr_size == 0);
+
+    constexpr auto const_arr0_size = detail::span_default_constructed_size<const std::array<int, 0>>();
+    BOOST_STATIC_ASSERT(const_arr0_size == 0);
+    constexpr auto const_arr2_size = detail::span_default_constructed_size<const std::array<int, 2>>();
+    BOOST_STATIC_ASSERT(const_arr2_size == 2);
+
+#ifdef __cpp_lib_integral_constant_callable
+    constexpr auto my_array3_size = detail::span_default_constructed_size<MyArray3>();
+    BOOST_STATIC_ASSERT(my_array3_size == 3);
+#endif
+
+#if __cplusplus >= 202302L
+    // static extent span has no default constructor so we can not determine size
+    constexpr auto span0_size = detail::span_default_constructed_size<std::span<int, 0>>();
+    BOOST_STATIC_ASSERT(span0_size == 0);
+    constexpr auto span1_size = detail::span_default_constructed_size<std::span<int, 1>>();
+    BOOST_STATIC_ASSERT(span1_size == 0);
+    constexpr auto span2_size = detail::span_default_constructed_size<std::span<int, 2>>();
+    BOOST_STATIC_ASSERT(span2_size == 0);
+
+    constexpr auto const_span2_size = detail::span_default_constructed_size<std::span<const int, 2>>();
+    BOOST_STATIC_ASSERT(const_span2_size == 0);
+
+    constexpr auto dyn_span_size = detail::span_default_constructed_size<std::span<int>>();
+    BOOST_STATIC_ASSERT(dyn_span_size == 0);
+#endif
+}

--- a/test/span_incompatible_range_size_larger.cpp
+++ b/test/span_incompatible_range_size_larger.cpp
@@ -1,0 +1,9 @@
+#include <boost/array.hpp>
+#include <boost/core/span.hpp>
+
+int main()
+{
+    boost::array<int, 5> arr{};
+    boost::span<int, 4> sp{arr};
+    (void)sp;
+}

--- a/test/span_incompatible_range_size_smaller.cpp
+++ b/test/span_incompatible_range_size_smaller.cpp
@@ -1,0 +1,9 @@
+#include <boost/array.hpp>
+#include <boost/core/span.hpp>
+
+int main()
+{
+    boost::array<int, 3> arr{};
+    boost::span<int, 4> sp{arr};
+    (void)sp;
+}

--- a/test/span_undetectable_incompatible_range_size.cpp
+++ b/test/span_undetectable_incompatible_range_size.cpp
@@ -1,0 +1,37 @@
+#include <boost/array.hpp>
+#include <boost/core/span.hpp>
+#if __cplusplus >= 202302L
+#include <span>
+#endif
+#include <vector>
+
+int main()
+{
+    // many cases where constexpr default constructed container has 0 size, including C++20 onwards
+    // std::vector so we can not catch that case.
+    {
+        boost::array<int, 0> arr{};
+        boost::span<int, 4> sp{arr};
+        (void)sp;
+        std::vector<int> vec(10, 10);
+        boost::span<int, 4> sp2{vec};
+        (void)sp2;
+    }
+
+#if __cplusplus >= 202302L
+    // fixed extent std::span does not have default constructor so we can not get size
+    {
+        std::array<int, 4> arr{};
+        std::span<int, 4> std_sp{arr};
+        boost::span<int, 3> sp{std_sp};
+        (void)sp;
+    }
+    // no size check possible for dynamic extent std::span
+    {
+        std::array<int, 4> arr{};
+        std::span<int> std_sp{arr};
+        boost::span<int, 3> sp{std_sp};
+        (void)sp;
+    }
+#endif
+}


### PR DESCRIPTION

Based on discussion in https://github.com/boostorg/core/pull/179 / @pdimov  suggestion.

few notes
1. This will break some current code that does not exibit UB, for example constructing `span` of extent 3 from` boost::array `of size 4. As this is not allowed for `std::array` I presumed same logic should follow for other ranges.
2. I did not know a nicer C++11 way to produce an error message if extents do not match, so I used this mechanism with conversion of argument to resolve ambiguity
3. regarding formatting: I found no clang-format file in repo so I did my best to do what seems right
4. as for tests: I was trying to follow existing practices
5. lmk if comments are too extensive
6. if `span_default_constructed_size` works correctly maybe it should be moved to separate header if we think it will be useful in more places
7. I did not add runtime checks with `BOOST_ASSERT`, I prefer to do that in separate PR
8. I did not add checks for `max_size`, that may be useful for some fixed buffer types, e.g. [static_string](https://www.boost.org/doc/libs/1_86_0/libs/static_string/doc/html/static_string/ref/boost__static_strings__basic_static_string/max_size.html)
9. for `std::span` availability in test I used C++23 macro(I presume all C++23 compilers have all C++20 headers) since it is easier than to check for span header, if you prefer I can switch to specific span check
10. I used `boost::array` as a nice range type, I know core can not depend on almost anything, but I presumed it is fine in tests a I think boost array does not depend on core, if not let me know so I make a simple test type.
11. `b2 cxxstd=03 test` fails, not sure if that is fine as C++11 is new minimal Boost version