### PR TITLE
Avoid `-Wzero-as-null-pointer-constant` warning in string_view ctor

### DIFF
--- a/include/boost/core/detail/string_view.hpp
+++ b/include/boost/core/detail/string_view.hpp
@@ -378,7 +378,7 @@ public:
     }
 
     template<class End> BOOST_CXX14_CONSTEXPR basic_string_view( Ch const* first, End last,
-        typename boost::enable_if<boost::core::detail::is_same<End, Ch const*> >::type* = 0 ) BOOST_NOEXCEPT: p_( first ), n_( static_cast<size_type>( last - first ) )
+        typename boost::enable_if<boost::core::detail::is_same<End, Ch const*>, int >::type = 0 ) BOOST_NOEXCEPT: p_( first ), n_( static_cast<size_type>( last - first ) )
     {
         BOOST_ASSERT( last - first >= 0 );
     }
@@ -396,7 +396,7 @@ public:
 #endif
 
     template<class Ch2> basic_string_view( boost::basic_string_view<Ch2, std::char_traits<Ch2> > const& str,
-        typename boost::enable_if<boost::core::detail::is_same<Ch, Ch2> >::type* = 0 ) BOOST_NOEXCEPT: p_( str.data() ), n_( str.size() )
+        typename boost::enable_if<boost::core::detail::is_same<Ch, Ch2>, int >::type = 0 ) BOOST_NOEXCEPT: p_( str.data() ), n_( str.size() )
     {
     }
 


### PR DESCRIPTION
This is an issue for C++11 and up for e.g. Boost libs that want to ensure warning-free build.

Solution is simply to move the SFINAE expression to the template argument list to avoid the `<..>* = 0` default argument

Alternative: `enable_if<..., int>::type = 0`