### PR TITLE
Use bit scan intrinsic on Windows ARM64 platform

### DIFF
--- a/include/boost/core/bit.hpp
+++ b/include/boost/core/bit.hpp
@@ -28,7 +28,7 @@
 # pragma intrinsic(_BitScanForward)
 # pragma intrinsic(_BitScanReverse)
 
-# if defined(_M_X64)
+# if defined(_M_X64) || defined(_M_ARM64)
 #  pragma intrinsic(_BitScanForward64)
 #  pragma intrinsic(_BitScanReverse64)
 # endif
@@ -230,7 +230,7 @@ inline int countl_impl( boost::uint16_t x ) BOOST_NOEXCEPT
 
 #endif
 
-#if defined(_MSC_VER) && defined(_M_X64) && defined(BOOST_CORE_HAS_BUILTIN_ISCONSTEVAL)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64)) && defined(BOOST_CORE_HAS_BUILTIN_ISCONSTEVAL)
 
 BOOST_CXX14_CONSTEXPR inline int countl_impl( boost::uint64_t x ) BOOST_NOEXCEPT
 {
@@ -255,7 +255,7 @@ BOOST_CXX14_CONSTEXPR inline int countl_impl( boost::uint64_t x ) BOOST_NOEXCEPT
     }
 }
 
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
 
 inline int countl_impl( boost::uint64_t x ) BOOST_NOEXCEPT
 {
@@ -455,7 +455,7 @@ inline int countr_impl( boost::uint16_t x ) BOOST_NOEXCEPT
 
 #endif
 
-#if defined(_MSC_VER) && defined(_M_X64) && defined(BOOST_CORE_HAS_BUILTIN_ISCONSTEVAL)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64)) && defined(BOOST_CORE_HAS_BUILTIN_ISCONSTEVAL)
 
 BOOST_CXX14_CONSTEXPR inline int countr_impl( boost::uint64_t x ) BOOST_NOEXCEPT
 {
@@ -480,7 +480,7 @@ BOOST_CXX14_CONSTEXPR inline int countr_impl( boost::uint64_t x ) BOOST_NOEXCEPT
     }
 }
 
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
 
 inline int countr_impl( boost::uint64_t x ) BOOST_NOEXCEPT
 {


### PR DESCRIPTION
On [MSVC ARM64](https://learn.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=msvc-170) both `_BitScanForward64` and `_BitScanReverse64` are available. ARM runners [are not yet available](https://github.com/github/roadmap/issues/1098) with Github actions, but I have run this (and the entire core test suite) locally on an ARM64 Windows Machine:

<img width="1772" alt="Screenshot 2025-04-10 at 8 41 35 AM" src="https://github.com/user-attachments/assets/57eaf98b-5942-40f8-bb15-d2356c63fb9b" />
