### PR TITLE
Move Ubuntu 20.04 builds to container or newer Ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,13 @@ jobs:
           - toolset: gcc-9
             cxxstd: "03,11,14,17,2a"
             address-model: 32,64
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             install:
               - g++-9-multilib
           - toolset: gcc-10
             cxxstd: "03,11,14,17,20"
             address-model: 32,64
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             install:
               - g++-10-multilib
           - toolset: gcc-11
@@ -220,13 +220,15 @@ jobs:
           - toolset: clang
             compiler: clang++-9
             cxxstd: "03,11,14,17,2a"
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - clang-9
           - toolset: clang
             compiler: clang++-10
             cxxstd: "03,11,14,17,20"
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - clang-10
           - toolset: clang
@@ -635,7 +637,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: macos-13
@@ -703,7 +704,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: macos-13
@@ -781,7 +781,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: macos-13


### PR DESCRIPTION
The Ubuntu 20.04 image on GitHub Actions will be unavailable by 2025-04-15. See <https://github.com/actions/runner-images/issues/11101> for more information on the deprecation and removal.

Therefore all build jobs that use the Ubuntu 20.04 runner image of GHA have to be either migrated to a newer runner image (if the compiler version is available on a newer image) or have to be moved to Docker containers using Ubuntu 20.04 (if the compiler version is not available on the newer runner images).