### PR TITLE
:bug: Fix bit_ceil() to return 1 for input 0 as per specification

### DIFF
--- a/include/boost/core/bit.hpp
+++ b/include/boost/core/bit.hpp
@@ -703,7 +703,7 @@ BOOST_CXX14_CONSTEXPR inline boost::uint32_t bit_ceil_impl( boost::uint32_t x ) 
 {
     if( x == 0 )
     {
-        return 0;
+        return 1;
     }
 
     --x;
@@ -723,7 +723,7 @@ BOOST_CXX14_CONSTEXPR inline boost::uint64_t bit_ceil_impl( boost::uint64_t x ) 
 {
     if( x == 0 )
     {
-        return 0;
+        return 1;
     }
 
     --x;

--- a/test/bit_ceil_test.cpp
+++ b/test/bit_ceil_test.cpp
@@ -21,7 +21,7 @@ template<class T> void test_bit_ceil( T x )
 
     if( x == 0 )
     {
-        BOOST_TEST_EQ( y, 0 );
+        BOOST_TEST_EQ( y, 1 );
     }
     else
     {


### PR DESCRIPTION
## :bug: #197  Fix `bit_ceil()` to return 1 for input 0 as per specification

This PR fixes a bug in `boost::core::bit_ceil()` where the function returned `0` for an input of `0`. According to the specification, it should return `1`.

### 🔧 Changes
- Corrected the implementation of `bit_ceil()` to return `1` when called with `0`.
- Added test coverage to validate the corrected behaviour.

### ✅ Impact
Aligns the function with the expected and documented behaviour. This fix prevents potential logical errors in code relying on `bit_ceil(0)` returning `1`.